### PR TITLE
Proxy Password Authentication

### DIFF
--- a/src/main/java/com/treasure_data/client/Constants.java
+++ b/src/main/java/com/treasure_data/client/Constants.java
@@ -21,6 +21,10 @@ public interface Constants {
     String TD_ENV_API_KEY = "TREASURE_DATA_API_KEY";
     String TD_ENV_API_SERVER = "TD_API_SERVER";
 
+    // There's no "https.proxyUser". These settings are used both for http and https.
+    String HTTP_PROXY_USER = "http.proxyUser";
+    String HTTP_PROXY_PASSWORD = "http.proxyPassword";
+
     String TD_API_KEY = "td.api.key";
     String TD_INTERNAL_KEY = "td.api.internalkey";
     String TD_INTERNAL_KEY_ID = "td.api.internalkeyid";

--- a/src/test/java/com/treasure_data/client/TestHttpConnectionImpl.java
+++ b/src/test/java/com/treasure_data/client/TestHttpConnectionImpl.java
@@ -2,6 +2,7 @@ package com.treasure_data.client;
 
 import static com.treasure_data.client.HttpConnectionImpl.e;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
@@ -128,6 +129,19 @@ public class TestHttpConnectionImpl {
     @Test
     public void encode() throws Exception {
         assertEquals(e(" foo bar "), "%20foo%20bar%20");
+    }
+
+    @Test
+    public void proxyUser() {
+        Properties props = new Properties();
+        props.setProperty("http.proxyHost", "proxy");
+        props.setProperty("http.proxyPort", "8080");
+        HttpConnectionImpl conn = new HttpConnectionImpl(props);
+        assertTrue(conn.getAuthenticator() == null);
+        props.setProperty("http.proxyUser", "username");
+        props.setProperty("http.proxyPassword", "password");
+        conn = new HttpConnectionImpl(props);
+        assertTrue(conn.getAuthenticator() != null);
     }
 
     public static void assertURL(Properties props, String urlString, String expected) throws Exception {


### PR DESCRIPTION
Use system property "http.proxyUser" and "http.proxyPassword" for proxy
authentication that requires password. Bear in mind that Java's
HttpURLConnection honors "http.proxyHost" and "http.proxyPort" but it
does not use "http.proxyUser" and "http.proxyPassword".