### PR TITLE
Set Content-Length: 0 to POST request always

### DIFF
--- a/src/main/java/com/treasure_data/client/HttpConnectionImpl.java
+++ b/src/main/java/com/treasure_data/client/HttpConnectionImpl.java
@@ -172,6 +172,12 @@ public class HttpConnectionImpl {
         conn.connect();
     }
 
+    /*
+     * This method requires all 'params' are URL encoded as CGI parameters.
+     * Use HttpConnectionImpl.e() that does URLEncoder.encode() + '+' => '%20'.
+     *
+     * Preferably you should not use this method.
+     */
     public void doPostRequest(Request<?> request, String path, Map<String, String> header,
             Map<String, String> params) throws IOException {
         StringBuilder sbuf = new StringBuilder();
@@ -194,8 +200,12 @@ public class HttpConnectionImpl {
         } else {
             URL url = new URL(sbuf.toString());
             conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("Content-Length", "0");
         }
+        // this method always send POST content as CGI parameters.
+        // By calling setFixedLengthStreamingMode() with 0 this sets Content-Length: 0 to cope with
+        // old squid proxy server that returns 411 when it does not exist.
+        conn.setFixedLengthStreamingMode(0);
+        conn.setDoOutput(true);
         conn.setReadTimeout(postReadTimeout);
 
         // header


### PR DESCRIPTION
HttpConnectionImpl do POST not with message body in x-www-urlencoded but
with CGI parameters so Content-Length is always zero. Squid ~> 3.0
dislike the POST request that is HTTP/1.1 (keep-alive) and no
Content-Length definition and returns error.  This commit uses
HttpURLConnection#setFixedLengthStreamingMode(0) to set Content-Length
header properly.

NB. HttpURLConnection#setRequestProperty("Content-Length", n) is
ignored.