### PR TITLE
add accessor for pool_name to submit jobs into specified resource pool

### DIFF
--- a/src/main/java/com/treasure_data/client/DefaultClientAdaptorImpl.java
+++ b/src/main/java/com/treasure_data/client/DefaultClientAdaptorImpl.java
@@ -1505,6 +1505,9 @@ public class DefaultClientAdaptorImpl extends AbstractClientAdaptor implements
             }
             params.put("priority", "" + request.getJob().getPriority().getPriority());
             params.put("retry_limit", "" + request.getJob().getRetryLimit());
+            if (request.getJob().getPoolName() != null) {
+                params.put("pool_name", "" + request.getJob().getPoolName());
+            }
             conn.doPostRequest(request, path, header, params);
 
             // receive response code

--- a/src/main/java/com/treasure_data/model/Job.java
+++ b/src/main/java/com/treasure_data/model/Job.java
@@ -108,6 +108,8 @@ public class Job extends AbstractModel {
 
     private int retryLimit = 0;
 
+    private String poolName;
+
     public Job(String jobID) {
         this(jobID, Job.Type.HIVE, null, null, null);
     }
@@ -203,5 +205,13 @@ public class Job extends AbstractModel {
 
     public String getResultTable() {
         return resultTable;
+    }
+
+    public void setPoolName(String poolName) {
+        this.poolName = poolName;
+    }
+
+    public String getPoolName() {
+        return poolName;
     }
 }

--- a/src/test/java/com/treasure_data/client/TestSubmitJob.java
+++ b/src/test/java/com/treasure_data/client/TestSubmitJob.java
@@ -76,6 +76,24 @@ public class TestSubmitJob extends
         System.out.println(job.getJobID());
     }
 
+    @Test @Ignore
+    public void testSubmitJobWithPoolName() throws Exception {
+        Properties props = System.getProperties();
+        props.load(this.getClass().getClassLoader().getResourceAsStream("treasure-data.properties"));
+        Config conf = new Config();
+        conf.setCredentials(new TreasureDataCredentials(props));
+        DefaultClientAdaptorImpl clientAdaptor = new DefaultClientAdaptorImpl(conf);
+
+        Database database = new Database("mugadb");
+        String q = "select count(1) from score";
+        Job job = new Job(database, q, Priority.HIGH, 1);
+        job.setPoolName("hadoop2");
+        SubmitJobRequest request = new SubmitJobRequest(job);
+        SubmitJobResult result = clientAdaptor.submitJob(request);
+        job = result.getJob();
+        System.out.println(job.getJobID());
+    }
+
     @Override
     public void checkNormalBehavior0() throws Exception {
         SubmitJobResult result = doBusinessLogic();


### PR DESCRIPTION
This pull request is to add `pool_name` field when submitting jobs to Treasure Data, based on 0.5.x branch.