### PR TITLE
Configuring TDClient with TDClientBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import org.msgpack.value.ArrayValue;
 ...
 
 // Create a new TD client by using configurations in $HOME/.td/td.conf
-TDClient client = new TDClient();
+TDClient client = TDClient.newClient();
 
 // Retrieve database and table names
 List<String> databaseNames = client.listDatabases();
@@ -130,7 +130,7 @@ client.jobResult(jobId, TDResultFormat.MESSAGE_PACK_GZ, new Function<InputStream
 
 ```java
 // Create a new TD client by using configurations in $HOME/.td/td.conf
-TDClient client = new TDClient();
+TDClient client = TDClient.newClient();
 
 File f = new File("./sess/part01.msgpack.gz");
 
@@ -138,20 +138,28 @@ TDBulkImportSession session = client.createBulkImportSession("session_name", "da
 client.uploadBulkImportPart(session.getName(), "session_part01", f);
 ```
 
-### Custom Configuration
+### Configuring TDClient
 
-You can set configuration parameters by using ``$HOME/.td/td.conf`` file and `Properties` object:
+To configure TDClient, use `TDClient.newBuilder()`:
 
 ```java
-Properties prop = TDClientConfig.readTDConf(); // Set the default values by reading $HOME/.td/td.conf file
+TDClient client = TDClient
+    .newBuider()
+    .setApiKey("(your api key)")
+    .setEndPoint("ybi.jp-east.idcfcloud.com")   // For using a non-default endpoint
+    .build()
+```
+
+It is also possible to set the configuration with a `Properties` object:
+
+```java
+Properties prop = new Properties();
 // Set your own properties
-prop.setProperty("key", "value");
+prop.setProperty("td.client.retry.limit", "10");
 ...
 
-// This uses configuration parameters in the Properties object as the default values.
-// You can overwrite this by using System properties
-TDClietnConfig config = TDClientConfig.newConfig(p)
-TDClient client = new TDClient(config);
+// This overrides the default configuration parameters with the given Properties
+TDClient client = TDClient.newBuilder().setProperties(prop).build();
 ```
 
 ## List of Configuration Parameters
@@ -177,12 +185,14 @@ TDClient client = new TDClient(config);
 |`td.client.port` | 80 for non-SSL, 443 for SSL connection | (optional) TD API port number |
 
 
-You can overwrite the configurations by using environment variables or System properties. The precedence of the configuration parmeters are as follows:
+The precedence of the configuration parameters are as follows:
 
-1. Environment variable (only for TD_API_KEY parameter)
+1. Properties object passed to `TDClient.newBuilder().setProperties(Properties p)``
 1. System properties (passed with `-D` option when launching JVM)
-1. Properties object passed to TDClientConfig.newConfig(Properties p)
+1. Environment variable (only for TD_API_KEY parameter)
 
+You can override the default configuartion parameters given by the environment
+variables with System properties, and then by Properties object.
 
 ## For Developers
 

--- a/README.md
+++ b/README.md
@@ -187,12 +187,13 @@ TDClient client = TDClient.newBuilder().setProperties(prop).build();
 
 The precedence of the configuration parameters are as follows:
 
-1. Properties object passed to `TDClient.newBuilder().setProperties(Properties p)``
+1. Properties object passed to `TDClient.newBuilder().setProperties(Properties p)`
+1. Parameters written in `$HOME/.td/td.conf`
 1. System properties (passed with `-D` option when launching JVM)
 1. Environment variable (only for TD_API_KEY parameter)
 
-You can override the default configuartion parameters given by the environment
-variables with System properties, and then by Properties object.
+You can override the default configuration parameters given by the environment
+variables with System properties, and then by `$HOME/.td/td.conf` file or `Properties` object.
 
 ## For Developers
 

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -18,6 +18,7 @@
  */
 package com.treasuredata.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -91,15 +92,34 @@ public class TDClient
         logger.info("td-client version: " + version);
     }
 
-    private final TDClientConfig config;
-    private final TDHttpClient httpClient;
-    private final Optional<String> apiKeyCache;
-
-    public TDClient()
-            throws TDClientException
+    public static TDClient newClient()
     {
-        this(TDClientConfig.currentConfig());
+        return new TDClientBuilder(true).build();
     }
+
+    public static TDClientBuilder newBuilder()
+    {
+        return new TDClientBuilder(true);
+    }
+
+    /**
+     * Create a new TDClient that uses the given api key for the authentication.
+     * The new instance of TDClient shares the same HttpClient, so closing this will invalidate the other copy of TDClient instances
+     *
+     * @param newApiKey
+     * @return
+     */
+    @Override
+    public TDClient withApiKey(String newApiKey)
+    {
+        return new TDClient(config, httpClient, Optional.of(newApiKey));
+    }
+
+    @VisibleForTesting
+    final TDClientConfig config;
+    @VisibleForTesting
+    final TDHttpClient httpClient;
+    private final Optional<String> apiKeyCache;
 
     public TDClient(TDClientConfig config)
     {
@@ -170,19 +190,6 @@ public class TDClient
 
         TDApiRequest request = TDApiRequest.Builder.PUT(path).setFile(filePath).build();
         return httpClient.call(request, apiKeyCache);
-    }
-
-    /**
-     * Create a new TDClient that uses the given api key for the authentication.
-     * The new instance of TDClient shares the same HttpClient, so closing this will invalidate the other copy of TDClient instances
-     *
-     * @param newApiKey
-     * @return
-     */
-    @Override
-    public TDClient withApiKey(String newApiKey)
-    {
-        return new TDClient(config, httpClient, Optional.of(newApiKey));
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -103,7 +103,7 @@ public class TDClient
 
     public TDClient(TDClientConfig config)
     {
-        this(config, new TDHttpClient(config), config.getApiKey());
+        this(config, new TDHttpClient(config), config.apiKey);
     }
 
     protected TDClient(TDClientConfig config, TDHttpClient httpClient, Optional<String> apiKeyCache)

--- a/src/main/java/com/treasuredata/client/TDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/TDClientBuilder.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.treasuredata.client;
+
+import com.google.common.base.Optional;
+
+import java.util.Properties;
+
+import static com.treasuredata.client.TDClientConfig.ENV_TD_CLIENT_APIKEY;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_APIKEY;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_API_ENDPOINT;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_API_PORT;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_CONNECTION_POOL_SIZE;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_CONNECT_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_IDLE_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PASSOWRD;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_HOST;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_PASSWORD;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_PORT;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_USER;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_USESSL;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_LIMIT;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MULTIPLIER;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USER;
+import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USESSL;
+import static com.treasuredata.client.TDClientConfig.getTDConfProperties;
+
+/**
+ *
+ */
+public class TDClientBuilder
+{
+    private Optional<String> endpoint = Optional.absent();
+    private Optional<Integer> port = Optional.absent();
+    private boolean useSSL = true;
+    private Optional<String> apiKey = Optional.absent();
+    private Optional<String> user = Optional.absent();
+    private Optional<String> password = Optional.absent();
+    private Optional<ProxyConfig> proxy = Optional.absent();
+    private int retryLimit = 7;
+    private int retryInitialIntervalMillis = 500;
+    private int retryMaxIntervalMillis = 60000;
+    private double retryMultiplier = 2.0;
+    private int connectTimeoutMillis = 15000;
+    private int idleTimeoutMillis = 60000;
+    private int connectionPoolSize = 64;
+
+    private static Optional<String> getConfigProperty(Properties p, String key)
+    {
+        return Optional.fromNullable(p.getProperty(key));
+    }
+
+    private static Optional<Integer> getConfigPropertyInt(Properties p, String key)
+    {
+        String v = p.getProperty(key);
+        if (v != null) {
+            try {
+                return Optional.of(Integer.parseInt(v));
+            }
+            catch (NumberFormatException e) {
+                throw new TDClientException(TDClientException.ErrorType.INVALID_CONFIGURATION, String.format("[%s] cannot cast %s to integer", key, v));
+            }
+        }
+        else {
+            return Optional.absent();
+        }
+    }
+
+    private static Optional<Double> getConfigPropertyDouble(Properties p, String key)
+    {
+        String v = p.getProperty(key);
+        if (v != null) {
+            try {
+                return Optional.of(Double.parseDouble(v));
+            }
+            catch (NumberFormatException e) {
+                throw new TDClientException(TDClientException.ErrorType.INVALID_CONFIGURATION, String.format("[%s] cannot cast %s to double", key, v));
+            }
+        }
+        else {
+            return Optional.absent();
+        }
+    }
+
+    /**
+     * Create a new TDClinenb builder whose configuration is initialized with System Properties and $HOME/.td/td.conf values.
+     * Precedence of properties is the following order:
+     * <ol>
+     * <li>System Properties</li>
+     * <li>$HOME/.td/td.conf values</li>
+     * </ol>
+     *
+     * @return
+     */
+    public TDClientBuilder(boolean loadTDConf)
+    {
+        // load the environnment variable for the api key
+        String apiKeyEnv = System.getenv(ENV_TD_CLIENT_APIKEY);
+        if (apiKeyEnv != null) {
+            setApiKey(apiKeyEnv);
+        }
+
+        // load system properties
+        setProperties(System.getProperties());
+
+        // We also read $HOME/.td/td.conf file for apikey, user, and password values
+        if (loadTDConf) {
+            setProperties(getTDConfProperties());
+        }
+    }
+
+    /**
+     * Override the TDClient configuration with the give Properties
+     *
+     * @param p
+     * @return
+     */
+    public TDClientBuilder setProperties(Properties p)
+    {
+        this.endpoint = getConfigProperty(p, TD_CLIENT_API_ENDPOINT).or(endpoint);
+        this.port = getConfigPropertyInt(p, TD_CLIENT_API_PORT).or(port);
+        if (p.containsKey(TD_CLIENT_USESSL)) {
+            setUseSSL(Boolean.parseBoolean(p.getProperty(TD_CLIENT_USESSL)));
+        }
+        this.apiKey = getConfigProperty(p, TD_CLIENT_APIKEY)
+                .or(getConfigProperty(p, "apikey"))
+                .or(apiKey);
+        this.user = getConfigProperty(p, TD_CLIENT_USER)
+                .or(getConfigProperty(p, "user"))
+                .or(user);
+        this.password = getConfigProperty(p, TD_CLIENT_PASSOWRD)
+                .or(getConfigProperty(p, "password"))
+                .or(password);
+
+        // proxy
+        boolean hasProxy = false;
+        ProxyConfig.ProxyConfigBuilder proxyConfig;
+        if (proxy.isPresent()) {
+            hasProxy = true;
+            proxyConfig = new ProxyConfig.ProxyConfigBuilder(proxy.get());
+        }
+        else {
+            proxyConfig = new ProxyConfig.ProxyConfigBuilder();
+        }
+        Optional<String> proxyHost = getConfigProperty(p, TD_CLIENT_PROXY_HOST);
+        Optional<Integer> proxyPort = getConfigPropertyInt(p, TD_CLIENT_PROXY_PORT);
+        Optional<String> proxyUseSSL = getConfigProperty(p, TD_CLIENT_PROXY_USESSL);
+        Optional<String> proxyUser = getConfigProperty(p, TD_CLIENT_PROXY_USER);
+        Optional<String> proxyPassword = getConfigProperty(p, TD_CLIENT_PROXY_PASSWORD);
+        if (proxyHost.isPresent()) {
+            hasProxy = true;
+            proxyConfig.setHost(proxyHost.get());
+        }
+        if (proxyPort.isPresent()) {
+            hasProxy = true;
+            proxyConfig.setPort(proxyPort.get());
+        }
+        if (proxyUseSSL.isPresent()) {
+            hasProxy = true;
+            proxyConfig.useSSL(Boolean.parseBoolean(proxyUseSSL.get()));
+        }
+        if (proxyUser.isPresent()) {
+            hasProxy = true;
+            proxyConfig.setUser(proxyUser.get());
+        }
+        if (proxyPassword.isPresent()) {
+            hasProxy = true;
+            proxyConfig.setPassword(proxyPassword.get());
+        }
+        this.proxy = Optional.fromNullable(hasProxy ? proxyConfig.createProxyConfig() : null);
+
+        // http client parameter
+        this.retryLimit = getConfigPropertyInt(p, TD_CLIENT_RETRY_LIMIT).or(retryLimit);
+        this.retryInitialIntervalMillis = getConfigPropertyInt(p, TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS).or(retryInitialIntervalMillis);
+        this.retryMaxIntervalMillis = getConfigPropertyInt(p, TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS).or(retryMaxIntervalMillis);
+        this.retryMultiplier = getConfigPropertyDouble(p, TD_CLIENT_RETRY_MULTIPLIER).or(retryMultiplier);
+        this.connectTimeoutMillis = getConfigPropertyInt(p, TD_CLIENT_CONNECT_TIMEOUT_MILLIS).or(connectTimeoutMillis);
+        this.idleTimeoutMillis = getConfigPropertyInt(p, TD_CLIENT_IDLE_TIMEOUT_MILLIS).or(idleTimeoutMillis);
+        this.connectionPoolSize = getConfigPropertyInt(p, TD_CLIENT_CONNECTION_POOL_SIZE).or(connectionPoolSize);
+        return this;
+    }
+
+    public TDClientBuilder setEndpoint(String endpoint)
+    {
+        this.endpoint = Optional.of(endpoint);
+        return this;
+    }
+
+    public TDClientBuilder setPort(int port)
+    {
+        this.port = Optional.of(port);
+        return this;
+    }
+
+    public TDClientBuilder setUseSSL(boolean useSSL)
+    {
+        this.useSSL = useSSL;
+        return this;
+    }
+
+    public TDClientBuilder setApiKey(String apiKey)
+    {
+        this.apiKey = Optional.of(apiKey);
+        return this;
+    }
+
+    public TDClientBuilder setUser(String user)
+    {
+        this.user = Optional.of(user);
+        return this;
+    }
+
+    public TDClientBuilder setPassword(String password)
+    {
+        this.password = Optional.of(password);
+        return this;
+    }
+
+    public TDClientBuilder setProxy(ProxyConfig proxyConfig)
+    {
+        this.proxy = Optional.of(proxyConfig);
+        return this;
+    }
+
+    public TDClientBuilder setRetryLimit(int retryLimit)
+    {
+        this.retryLimit = retryLimit;
+        return this;
+    }
+
+    public TDClientBuilder setRetryInitialIntervalMillis(int retryInitialIntervalMillis)
+    {
+        this.retryInitialIntervalMillis = retryInitialIntervalMillis;
+        return this;
+    }
+
+    public TDClientBuilder setRetryMaxIntervalMillis(int retryMaxIntervalMillis)
+    {
+        this.retryMaxIntervalMillis = retryMaxIntervalMillis;
+        return this;
+    }
+
+    public void setRetryMultiplier(double retryMultiplier)
+    {
+        this.retryMultiplier = retryMultiplier;
+    }
+
+    public TDClientBuilder setConnectTimeoutMillis(int connectTimeoutMillis)
+    {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        return this;
+    }
+
+    public TDClientBuilder setIdleTimeoutMillis(int idleTimeoutMillis)
+    {
+        this.idleTimeoutMillis = idleTimeoutMillis;
+        return this;
+    }
+
+    public TDClientBuilder setConnectionPoolSize(int connectionPoolSize)
+    {
+        this.connectionPoolSize = connectionPoolSize;
+        return this;
+    }
+
+    public TDClient build()
+    {
+        return new TDClient(new TDClientConfig(
+                endpoint,
+                port,
+                useSSL,
+                apiKey,
+                user,
+                password,
+                proxy,
+                retryLimit,
+                retryInitialIntervalMillis,
+                retryMaxIntervalMillis,
+                retryMultiplier,
+                connectTimeoutMillis,
+                idleTimeoutMillis,
+                connectionPoolSize
+        ));
+    }
+}

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -62,22 +62,22 @@ public class TDClientConfig
     /**
      * endpoint URL (e.g., api.treasuredata.com, ybi.jp-east.idcfcloud.com)
      */
-    private final String endpoint;
-    private final Optional<Integer> port;
-    private final Optional<String> apiKey;
-    private final Optional<String> user;
-    private final Optional<String> password;
-    private final Optional<ProxyConfig> proxy;
-    private final String httpScheme;
-    private final boolean useSSL;
-    private final int retryLimit;
-    private final int retryInitialIntervalMillis;
-    private final int retryMaxIntervalMillis;
-    private final double retryMultiplier;
-    private final int connectTimeoutMillis;
-    private final int idleTimeoutMillis;
-    private final int connectionPoolSize;
-    private static Properties tdConf;
+    public final String endpoint;
+    public final Optional<Integer> port;
+    public final Optional<String> apiKey;
+    public final Optional<String> user;
+    public final Optional<String> password;
+    public final Optional<ProxyConfig> proxy;
+    public final String httpScheme;
+    public final boolean useSSL;
+    public final int retryLimit;
+    public final int retryInitialIntervalMillis;
+    public final int retryMaxIntervalMillis;
+    public final double retryMultiplier;
+    public final int connectTimeoutMillis;
+    public final int idleTimeoutMillis;
+    public final int connectionPoolSize;
+    public static Properties tdConf;
 
     public TDClientConfig withProxy(ProxyConfig proxy)
     {
@@ -155,81 +155,6 @@ public class TDClientConfig
         this.connectTimeoutMillis = connectTimeoutMillis;
         this.idleTimeoutMillis = idleTimeoutMillis;
         this.connectionPoolSize = connectionPoolSize;
-    }
-
-    public String getEndpoint()
-    {
-        return endpoint;
-    }
-
-    public Optional<String> getApiKey()
-    {
-        return apiKey;
-    }
-
-    public Optional<String> getUser()
-    {
-        return user;
-    }
-
-    public Optional<String> getPassword()
-    {
-        return password;
-    }
-
-    public int getRetryLimit()
-    {
-        return retryLimit;
-    }
-
-    public int getRetryInitialIntervalMillis()
-    {
-        return retryInitialIntervalMillis;
-    }
-
-    public int getRetryMaxIntervalMillis()
-    {
-        return retryMaxIntervalMillis;
-    }
-
-    public double getRetryMultiplier()
-    {
-        return retryMultiplier;
-    }
-
-    public int getConnectTimeoutMillis()
-    {
-        return connectTimeoutMillis;
-    }
-
-    public int getIdleTimeoutMillis()
-    {
-        return idleTimeoutMillis;
-    }
-
-    public int getConnectionPoolSize()
-    {
-        return connectionPoolSize;
-    }
-
-    public Optional<Integer> getPort()
-    {
-        return port;
-    }
-
-    public Optional<ProxyConfig> getProxy()
-    {
-        return proxy;
-    }
-
-    public String getHttpScheme()
-    {
-        return httpScheme;
-    }
-
-    public boolean isUseSSL()
-    {
-        return useSSL;
     }
 
     /**

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -36,7 +36,6 @@ import java.util.Properties;
  */
 public class TDClientConfig
 {
-    private static Logger logger = LoggerFactory.getLogger(TDClientConfig.class);
     public static final String ENV_TD_CLIENT_APIKEY = "TD_API_KEY";
     /**
      * Keys for configuring TDClient with a properties file (or System properties)
@@ -68,7 +67,6 @@ public class TDClientConfig
     public final Optional<String> user;
     public final Optional<String> password;
     public final Optional<ProxyConfig> proxy;
-    public final String httpScheme;
     public final boolean useSSL;
     public final int retryLimit;
     public final int retryInitialIntervalMillis;
@@ -77,50 +75,6 @@ public class TDClientConfig
     public final int connectTimeoutMillis;
     public final int idleTimeoutMillis;
     public final int connectionPoolSize;
-    public static Properties tdConf;
-
-    public TDClientConfig withProxy(ProxyConfig proxy)
-    {
-        return new Builder(this).setProxyConfig(proxy).build();
-    }
-
-    /**
-     * Get the default TDClientConfig by reading $HOME/.td/td.conf file.
-     *
-     * @return
-     * @throws IOException
-     * @throws TDClientException
-     */
-    public static TDClientConfig currentConfig()
-            throws TDClientException
-    {
-        return newBuilder().build();
-    }
-
-    public static Builder newBuilder()
-    {
-        if (tdConf == null) {
-            tdConf = readTDConf();
-        }
-        return new Builder(tdConf);
-    }
-
-    /**
-     * Create a new td-client configuration initialized with System Properties and the given properties for the default values.
-     * Precedence of properties is the following order:
-     * <ol>
-     * <li>System Properties</li>
-     * <li>Given Properties Object</li>
-     * </ol>
-     *
-     * @param p the default values
-     * @return
-     */
-    public static TDClientConfig newConfig(Properties p)
-    {
-        Builder b = new Builder(p);
-        return b.build();
-    }
 
     @JsonCreator
     public TDClientConfig(
@@ -140,7 +94,6 @@ public class TDClientConfig
             int connectionPoolSize
     )
     {
-        this.httpScheme = useSSL ? "https://" : "http://";
         this.endpoint = endpoint.or("api.treasuredata.com");
         this.port = port;
         this.useSSL = useSSL;
@@ -155,6 +108,24 @@ public class TDClientConfig
         this.connectTimeoutMillis = connectTimeoutMillis;
         this.idleTimeoutMillis = idleTimeoutMillis;
         this.connectionPoolSize = connectionPoolSize;
+    }
+
+    private static Logger logger = LoggerFactory.getLogger(TDClientConfig.class);
+    private static Properties tdConf;
+
+    /**
+     * Get the default TDClientConfig by reading $HOME/.td/td.conf file.
+     *
+     * @return
+     * @throws IOException
+     * @throws TDClientException
+     */
+    static Properties getTDConfProperties()
+    {
+        if (tdConf == null) {
+            tdConf = readTDConf();
+        }
+        return tdConf;
     }
 
     /**
@@ -195,266 +166,6 @@ public class TDClientConfig
         }
         catch (IOException e) {
             throw new TDClientException(TDClientException.ErrorType.INVALID_CONFIGURATION, String.format("Failed to read config file: %s", file), e);
-        }
-    }
-
-    public static String firstNonNull(String... values)
-    {
-        for (String v : values) {
-            if (v != null) {
-                return v;
-            }
-        }
-        return null;
-    }
-
-    public static class Builder
-    {
-        private Optional<String> endpoint = Optional.absent();
-        private Optional<Integer> port = Optional.absent();
-        private boolean useSSL;
-        private Optional<String> apiKey = Optional.absent();
-        private Optional<String> user = Optional.absent();
-        private Optional<String> password = Optional.absent();
-        private Optional<ProxyConfig> proxy = Optional.absent();
-        private int retryLimit;
-        private int retryInitialIntervalMillis;
-        private int retryMaxIntervalMillis;
-        private double retryMultiplier;
-        private int connectTimeoutMillis;
-        private int idleTimeoutMillis;
-        private int connectionPoolSize;
-
-        private static Optional<String> getConfigProperty(String key, Properties defaultProperty)
-        {
-            return Optional.fromNullable(firstNonNull(System.getProperty(key), defaultProperty.getProperty(key)));
-        }
-
-        private static Optional<Integer> getConfigPropertyInt(String key, Properties defaultProperty)
-        {
-            String v = firstNonNull(System.getProperty(key), defaultProperty.getProperty(key));
-            if (v != null) {
-                try {
-                    return Optional.of(Integer.parseInt(v));
-                }
-                catch (NumberFormatException e) {
-                    throw new TDClientException(TDClientException.ErrorType.INVALID_CONFIGURATION, String.format("[%s] cannot cast %s to integer", key, v));
-                }
-            }
-            else {
-                return Optional.absent();
-            }
-        }
-
-        private static Optional<Double> getConfigPropertyDouble(String key, Properties defaultProperty)
-        {
-            String v = firstNonNull(System.getProperty(key), defaultProperty.getProperty(key));
-            if (v != null) {
-                try {
-                    return Optional.of(Double.parseDouble(v));
-                }
-                catch (NumberFormatException e) {
-                    throw new TDClientException(TDClientException.ErrorType.INVALID_CONFIGURATION, String.format("[%s] cannot cast %s to double", key, v));
-                }
-            }
-            else {
-                return Optional.absent();
-            }
-        }
-
-        Builder()
-        {
-            this(new Properties());
-        }
-
-        /***
-         * Constructor used for copying and overwriting an existing configuration
-         *
-         * @param config
-         */
-        Builder(TDClientConfig config)
-        {
-            this.endpoint = Optional.of(config.endpoint);
-            this.port = config.port;
-            this.useSSL = config.useSSL;
-            this.apiKey = config.apiKey;
-            this.user = config.user;
-            this.password = config.password;
-            this.proxy = config.proxy;
-            this.retryLimit = config.retryLimit;
-            this.retryInitialIntervalMillis = config.retryInitialIntervalMillis;
-            this.retryMaxIntervalMillis = config.retryMaxIntervalMillis;
-            this.retryMultiplier = config.retryMultiplier;
-            this.connectTimeoutMillis = config.connectTimeoutMillis;
-            this.idleTimeoutMillis = config.idleTimeoutMillis;
-            this.connectionPoolSize = config.connectionPoolSize;
-        }
-
-        /**
-         * Populate a builder populated with the default values. Precedence of the default values is:
-         * - Environment variable
-         * - System property
-         * - Given Property object
-         *
-         * @param defaultValues
-         */
-        Builder(Properties defaultValues)
-        {
-            this.endpoint = getConfigProperty(TD_CLIENT_API_ENDPOINT, defaultValues);
-            this.port = getConfigPropertyInt(TD_CLIENT_API_PORT, defaultValues);
-            this.useSSL = Boolean.parseBoolean(getConfigProperty(TD_CLIENT_USESSL, defaultValues).or("true"));
-
-            // For APIKEY we read the environment variable.
-            // We also read apikey, user and password specified in td.conf file
-            this.apiKey = Optional.fromNullable(System.getenv(ENV_TD_CLIENT_APIKEY))
-                    .or(getConfigProperty(TD_CLIENT_APIKEY, defaultValues))
-                    .or(Optional.fromNullable(defaultValues.getProperty("apikey")));
-            this.user = getConfigProperty(TD_CLIENT_USER, defaultValues)
-                    .or(Optional.fromNullable(defaultValues.getProperty("user")));
-            this.password = getConfigProperty(TD_CLIENT_PASSOWRD, defaultValues)
-                    .or(Optional.fromNullable(defaultValues.getProperty("password")));
-
-            // proxy
-            Optional<String> proxyHost = getConfigProperty(TD_CLIENT_PROXY_HOST, defaultValues);
-            Optional<Integer> proxyPort = getConfigPropertyInt(TD_CLIENT_PROXY_PORT, defaultValues);
-            Optional<String> proxyUseSSL = getConfigProperty(TD_CLIENT_PROXY_USESSL, defaultValues);
-            Optional<String> proxyUser = getConfigProperty(TD_CLIENT_PROXY_USER, defaultValues);
-            Optional<String> proxyPassword = getConfigProperty(TD_CLIENT_PROXY_PASSWORD, defaultValues);
-            boolean hasProxy = false;
-            ProxyConfig.ProxyConfigBuilder proxyConfig = new ProxyConfig.ProxyConfigBuilder();
-            if (proxyHost.isPresent()) {
-                hasProxy = true;
-                proxyConfig.setHost(proxyHost.get());
-            }
-            if (proxyPort.isPresent()) {
-                hasProxy = true;
-                proxyConfig.setPort(proxyPort.get());
-            }
-            if (proxyUseSSL.isPresent()) {
-                hasProxy = true;
-                proxyConfig.useSSL(Boolean.parseBoolean(proxyUseSSL.get()));
-            }
-            if (proxyUser.isPresent()) {
-                hasProxy = true;
-                proxyConfig.setUser(proxyUser.get());
-            }
-            if (proxyPassword.isPresent()) {
-                hasProxy = true;
-                proxyConfig.setPassword(proxyPassword.get());
-            }
-            this.proxy = Optional.fromNullable(hasProxy ? proxyConfig.createProxyConfig() : null);
-
-            // http client parameter
-            this.retryLimit = getConfigPropertyInt(TD_CLIENT_RETRY_LIMIT, defaultValues).or(7);
-            this.retryInitialIntervalMillis = getConfigPropertyInt(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS, defaultValues).or(500);
-            this.retryMaxIntervalMillis = getConfigPropertyInt(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS, defaultValues).or(60000);
-            this.retryMultiplier = getConfigPropertyDouble(TD_CLIENT_RETRY_MULTIPLIER, defaultValues).or(2.0);
-            this.connectTimeoutMillis = getConfigPropertyInt(TD_CLIENT_CONNECT_TIMEOUT_MILLIS, defaultValues).or(15000);
-            this.idleTimeoutMillis = getConfigPropertyInt(TD_CLIENT_IDLE_TIMEOUT_MILLIS, defaultValues).or(60000);
-            this.connectionPoolSize = getConfigPropertyInt(TD_CLIENT_CONNECTION_POOL_SIZE, defaultValues).or(64);
-        }
-
-        public Builder setEndpoint(String endpoint)
-        {
-            this.endpoint = Optional.of(endpoint);
-            return this;
-        }
-
-        public Builder setPort(int port)
-        {
-            this.port = Optional.of(port);
-            return this;
-        }
-
-        public Builder setUseSSL(boolean useSSL)
-        {
-            this.useSSL = useSSL;
-            return this;
-        }
-
-        public Builder setApiKey(String apiKey)
-        {
-            this.apiKey = Optional.of(apiKey);
-            return this;
-        }
-
-        public Builder setUser(String user)
-        {
-            this.user = Optional.of(user);
-            return this;
-        }
-
-        public Builder setPassword(String password)
-        {
-            this.password = Optional.of(password);
-            return this;
-        }
-
-        public Builder setProxyConfig(ProxyConfig proxyConfig)
-        {
-            this.proxy = Optional.of(proxyConfig);
-            return this;
-        }
-
-        public Builder setRetryLimit(int retryLimit)
-        {
-            this.retryLimit = retryLimit;
-            return this;
-        }
-
-        public Builder setRetryInitialIntervalMillis(int retryInitialIntervalMillis)
-        {
-            this.retryInitialIntervalMillis = retryInitialIntervalMillis;
-            return this;
-        }
-
-        public Builder setRetryMaxIntervalMillis(int retryMaxIntervalMillis)
-        {
-            this.retryMaxIntervalMillis = retryMaxIntervalMillis;
-            return this;
-        }
-
-        public void setRetryMultiplier(double retryMultiplier)
-        {
-            this.retryMultiplier = retryMultiplier;
-        }
-
-        public Builder setConnectTimeoutMillis(int connectTimeoutMillis)
-        {
-            this.connectTimeoutMillis = connectTimeoutMillis;
-            return this;
-        }
-
-        public Builder setIdleTimeoutMillis(int idleTimeoutMillis)
-        {
-            this.idleTimeoutMillis = idleTimeoutMillis;
-            return this;
-        }
-
-        public Builder setConnectionPoolSize(int connectionPoolSize)
-        {
-            this.connectionPoolSize = connectionPoolSize;
-            return this;
-        }
-
-        public TDClientConfig build()
-        {
-            return new TDClientConfig(
-                    endpoint,
-                    port,
-                    useSSL,
-                    apiKey,
-                    user,
-                    password,
-                    proxy,
-                    retryLimit,
-                    retryInitialIntervalMillis,
-                    retryMaxIntervalMillis,
-                    retryMultiplier,
-                    connectTimeoutMillis,
-                    idleTimeoutMillis,
-                    connectionPoolSize
-            );
         }
     }
 }

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -176,7 +176,7 @@ public class TDHttpClient
                 return ":" + input.toString();
             }
         }).or("");
-        String requestUri = String.format("%s%s%s%s", config.httpScheme, config.endpoint, portStr, apiRequest.getPath());
+        String requestUri = String.format("%s://%s%s%s", config.useSSL ? "https" : "http", config.endpoint, portStr, apiRequest.getPath());
 
         if (!apiRequest.getQueryParams().isEmpty()) {
             List<String> queryParamList = new ArrayList<String>(apiRequest.getQueryParams().size());

--- a/src/test/java/com/treasuredata/client/TestProxyAccess.java
+++ b/src/test/java/com/treasuredata/client/TestProxyAccess.java
@@ -160,7 +160,7 @@ public class TestProxyAccess
     @Test
     public void proxyApiAccess()
     {
-        TDClient client = new TDClient(TDClientConfig.currentConfig().withProxy(proxyBaseConfig()));
+        TDClient client = TDClient.newBuilder().setProxy(proxyBaseConfig()).build();
         try {
             client.serverStatus();
 
@@ -181,7 +181,7 @@ public class TestProxyAccess
     {
         ProxyConfig.ProxyConfigBuilder proxy = new ProxyConfig.ProxyConfigBuilder(proxyBaseConfig());
         proxy.setPassword(PROXY_PASS + "---"); // Use an wrong password
-        TDClient client = new TDClient(TDClientConfig.currentConfig().withProxy(proxy.createProxyConfig()));
+        TDClient client = TDClient.newBuilder().setProxy(proxy.createProxyConfig()).build();
         try {
             client.listTables("sample_datasets");
             fail("should not reach here");

--- a/src/test/java/com/treasuredata/client/TestSSLProxyAccess.java
+++ b/src/test/java/com/treasuredata/client/TestSSLProxyAccess.java
@@ -100,7 +100,7 @@ public class TestSSLProxyAccess
         proxy.setPort(proxyPort);
         proxy.setUser(PROXY_USER);
         proxy.setPassword(PROXY_PASS);
-        TDClient client = new TDClient(TDClientConfig.currentConfig().withProxy(proxy.createProxyConfig()));
+        TDClient client = TDClient.newBuilder().setProxy(proxy.createProxyConfig()).build();
         try {
             client.serverStatus();
 
@@ -125,7 +125,7 @@ public class TestSSLProxyAccess
         proxy.setPort(proxyPort);
         proxy.setUser(PROXY_USER);
         proxy.setPassword(PROXY_PASS + "---"); // Use an wrong password
-        TDClient client = new TDClient(TDClientConfig.currentConfig().withProxy(proxy.createProxyConfig()));
+        TDClient client = TDClient.newBuilder().setProxy(proxy.createProxyConfig()).build();
         try {
             client.listTables("sample_datasets");
             fail("should not reach here");

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -150,14 +150,13 @@ public class TestServerFailures
         });
         startServer();
 
-        TDClientConfig config = TDClientConfig
+        TDClient client = TDClient
                 .newBuilder()
                 .setEndpoint("localhost")
                 .setUseSSL(false)
                 .setPort(port)
                 .setRetryLimit(3)
                 .build();
-        TDClient client = new TDClient(config);
         try {
             client.serverStatus();
             fail("cannot reach here");
@@ -190,13 +189,11 @@ public class TestServerFailures
         });
         startServer();
 
-        TDClientConfig config = TDClientConfig
-                .newBuilder()
+        TDClient client = TDClient.newBuilder()
                 .setEndpoint("localhost")
                 .setUseSSL(false)
                 .setPort(port)
                 .build();
-        TDClient client = new TDClient(config);
         try {
             client.serverStatus();
             fail("cannot reach here");
@@ -243,13 +240,12 @@ public class TestServerFailures
         });
         startServer();
 
-        TDClientConfig config = TDClientConfig
+        TDClient client = TDClient
                 .newBuilder()
                 .setEndpoint("localhost")
                 .setUseSSL(false)
                 .setPort(port)
                 .build();
-        TDClient client = new TDClient(config);
         try {
             client.listDatabaseNames();
             fail("cannot reach here");

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -329,7 +329,7 @@ public class TestTDClient
             throws Exception
     {
         client.deleteTableIfExists(SAMPLE_DB, "sample_output");
-        String resultOutput = String.format("td://%s@/%s/sample_output?mode=replace", TDClientConfig.currentConfig().getApiKey().get(), SAMPLE_DB);
+        String resultOutput = String.format("td://%s@/%s/sample_output?mode=replace", TDClientConfig.currentConfig().apiKey.get(), SAMPLE_DB);
         String jobId = client.submit(TDJobRequest.newPrestoQuery("sample_datasets", "-- td-client-java test\nselect count(*) from nasdaq", resultOutput));
         TDJobSummary tdJob = waitJobCompletion(jobId);
         client.existsTable(SAMPLE_DB, "sample_output");

--- a/src/test/java/com/treasuredata/client/TestTDClientConfig.java
+++ b/src/test/java/com/treasuredata/client/TestTDClientConfig.java
@@ -76,18 +76,18 @@ public class TestTDClientConfig
 
     private void validate(TDClientConfig config)
     {
-        assertEquals(m.get(TD_CLIENT_API_ENDPOINT), config.getEndpoint());
-        assertEquals(m.get(TD_CLIENT_API_PORT), config.getPort().get());
-        assertEquals(m.get(TD_CLIENT_USESSL), config.isUseSSL());
-        assertEquals(m.get(TD_CLIENT_CONNECT_TIMEOUT_MILLIS), config.getConnectTimeoutMillis());
-        assertEquals(m.get(TD_CLIENT_CONNECTION_POOL_SIZE), config.getConnectionPoolSize());
-        assertEquals(m.get(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS), config.getRetryInitialIntervalMillis());
-        assertEquals(m.get(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS), config.getRetryMaxIntervalMillis());
-        assertEquals((double) m.get(TD_CLIENT_RETRY_MULTIPLIER), config.getRetryMultiplier(), 0.001);
-        assertEquals(m.get(TD_CLIENT_RETRY_LIMIT), config.getRetryLimit());
-        assertEquals(m.get(TD_CLIENT_USER), config.getUser().get());
-        assertEquals(m.get(TD_CLIENT_PASSOWRD), config.getPassword().get());
-        assertFalse(config.getProxy().isPresent());
+        assertEquals(m.get(TD_CLIENT_API_ENDPOINT), config.endpoint);
+        assertEquals(m.get(TD_CLIENT_API_PORT), config.port.get());
+        assertEquals(m.get(TD_CLIENT_USESSL), config.useSSL);
+        assertEquals(m.get(TD_CLIENT_CONNECT_TIMEOUT_MILLIS), config.connectTimeoutMillis);
+        assertEquals(m.get(TD_CLIENT_CONNECTION_POOL_SIZE), config.connectionPoolSize);
+        assertEquals(m.get(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS), config.retryInitialIntervalMillis);
+        assertEquals(m.get(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS), config.retryMaxIntervalMillis);
+        assertEquals((double) m.get(TD_CLIENT_RETRY_MULTIPLIER), config.retryMultiplier, 0.001);
+        assertEquals(m.get(TD_CLIENT_RETRY_LIMIT), config.retryLimit);
+        assertEquals(m.get(TD_CLIENT_USER), config.user.get());
+        assertEquals(m.get(TD_CLIENT_PASSOWRD), config.password.get());
+        assertFalse(config.proxy.isPresent());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class TestTDClientConfig
             p.setProperty(e.getKey(), e.getValue().toString());
         }
         TDClientConfig config = newConfig(p);
-        ProxyConfig proxy = config.getProxy().get();
+        ProxyConfig proxy = config.proxy.get();
         assertEquals(m.get(TD_CLIENT_PROXY_HOST), proxy.getHost());
         assertEquals(m.get(TD_CLIENT_PROXY_PORT), proxy.getPort());
         assertEquals(m.get(TD_CLIENT_PROXY_USER), proxy.getUser().get());

--- a/src/test/java/com/treasuredata/client/TestTDClientConfig.java
+++ b/src/test/java/com/treasuredata/client/TestTDClientConfig.java
@@ -65,6 +65,7 @@ public class TestTDClientConfig
         p.put(TD_CLIENT_CONNECT_TIMEOUT_MILLIS, 2345);
         p.put(TD_CLIENT_IDLE_TIMEOUT_MILLIS, 3456);
         p.put(TD_CLIENT_CONNECTION_POOL_SIZE, 234);
+        p.put(TD_CLIENT_IDLE_TIMEOUT_MILLIS, 143);
         p.put(TD_CLIENT_RETRY_LIMIT, 11);
         p.put(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS, 456);
         p.put(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS, 10000);
@@ -81,6 +82,7 @@ public class TestTDClientConfig
         assertEquals(m.get(TD_CLIENT_USESSL), config.useSSL);
         assertEquals(m.get(TD_CLIENT_CONNECT_TIMEOUT_MILLIS), config.connectTimeoutMillis);
         assertEquals(m.get(TD_CLIENT_CONNECTION_POOL_SIZE), config.connectionPoolSize);
+        assertEquals(m.get(TD_CLIENT_IDLE_TIMEOUT_MILLIS), config.idleTimeoutMillis);
         assertEquals(m.get(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS), config.retryInitialIntervalMillis);
         assertEquals(m.get(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS), config.retryMaxIntervalMillis);
         assertEquals((double) m.get(TD_CLIENT_RETRY_MULTIPLIER), config.retryMultiplier, 0.001);
@@ -108,6 +110,7 @@ public class TestTDClientConfig
         b.setUseSSL(Boolean.parseBoolean(m.get(TD_CLIENT_USESSL).toString()));
         b.setConnectTimeoutMillis(Integer.parseInt(m.get(TD_CLIENT_CONNECT_TIMEOUT_MILLIS).toString()));
         b.setConnectionPoolSize(Integer.parseInt(m.get(TD_CLIENT_CONNECTION_POOL_SIZE).toString()));
+        b.setIdleTimeoutMillis(Integer.parseInt(m.get(TD_CLIENT_IDLE_TIMEOUT_MILLIS).toString()));
         b.setRetryInitialIntervalMillis(Integer.parseInt(m.get(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS).toString()));
         b.setRetryMaxIntervalMillis(Integer.parseInt(m.get(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS).toString()));
         b.setRetryMultiplier(Double.parseDouble(m.get(TD_CLIENT_RETRY_MULTIPLIER).toString()));

--- a/src/test/java/com/treasuredata/client/TestTDClientConfig.java
+++ b/src/test/java/com/treasuredata/client/TestTDClientConfig.java
@@ -43,7 +43,6 @@ import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MAX_INTERVA
 import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MULTIPLIER;
 import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USER;
 import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USESSL;
-import static com.treasuredata.client.TDClientConfig.newConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -65,7 +64,6 @@ public class TestTDClientConfig
         p.put(TD_CLIENT_CONNECT_TIMEOUT_MILLIS, 2345);
         p.put(TD_CLIENT_IDLE_TIMEOUT_MILLIS, 3456);
         p.put(TD_CLIENT_CONNECTION_POOL_SIZE, 234);
-        p.put(TD_CLIENT_IDLE_TIMEOUT_MILLIS, 143);
         p.put(TD_CLIENT_RETRY_LIMIT, 11);
         p.put(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS, 456);
         p.put(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS, 10000);
@@ -100,11 +98,12 @@ public class TestTDClientConfig
         for (Map.Entry<String, Object> e : m.entrySet()) {
             p.setProperty(e.getKey(), e.getValue().toString());
         }
-        TDClientConfig config = newConfig(p);
+        TDClient client = TDClient.newBuilder().setProperties(p).build();
+        TDClientConfig config = client.config;
         validate(config);
 
         // Configuration via setters
-        TDClientConfig.Builder b = TDClientConfig.newBuilder();
+        TDClientBuilder b = TDClient.newBuilder();
         b.setEndpoint(m.get(TD_CLIENT_API_ENDPOINT).toString());
         b.setPort(Integer.parseInt(m.get(TD_CLIENT_API_PORT).toString()));
         b.setUseSSL(Boolean.parseBoolean(m.get(TD_CLIENT_USESSL).toString()));
@@ -117,7 +116,7 @@ public class TestTDClientConfig
         b.setRetryLimit(Integer.parseInt(m.get(TD_CLIENT_RETRY_LIMIT).toString()));
         b.setUser(m.get(TD_CLIENT_USER).toString());
         b.setPassword(m.get(TD_CLIENT_PASSOWRD).toString());
-        TDClientConfig config2 = b.build();
+        TDClientConfig config2 = b.build().config;
         validate(config2);
     }
 
@@ -134,7 +133,7 @@ public class TestTDClientConfig
         for (Map.Entry<String, Object> e : m.entrySet()) {
             p.setProperty(e.getKey(), e.getValue().toString());
         }
-        TDClientConfig config = newConfig(p);
+        TDClientConfig config = TDClient.newBuilder().setProperties(p).build().config;
         ProxyConfig proxy = config.proxy.get();
         assertEquals(m.get(TD_CLIENT_PROXY_HOST), proxy.getHost());
         assertEquals(m.get(TD_CLIENT_PROXY_PORT), proxy.getPort());
@@ -172,7 +171,7 @@ public class TestTDClientConfig
     {
         Properties p = new Properties();
         p.setProperty(TD_CLIENT_API_PORT, "xxxx");
-        TDClientConfig.newConfig(p);
+        TDClient.newBuilder().setProperties(p);
     }
 
     @Test(expected = TDClientException.class)
@@ -180,6 +179,6 @@ public class TestTDClientConfig
     {
         Properties p = new Properties();
         p.setProperty(TD_CLIENT_RETRY_MULTIPLIER, "xxx");
-        TDClientConfig.newConfig(p);
+        TDClient.newBuilder().setProperties(p);
     }
 }

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -43,7 +43,7 @@ public class TestTDHttpClient
     public void setUp()
             throws Exception
     {
-        client = new TDHttpClient(TDClientConfig.currentConfig());
+        client = TDClient.newClient().httpClient;
     }
 
     @After


### PR DESCRIPTION
- Removed TDConfig builder, instead added `TDClient.newBuilder()`. 
 - It makes easy to remember the start point of configuring TDClient.
 - It also reduces the code size related to TDClientConfig
 - Using public final field for TDClientConfig and ProxyConfig object.


