### PR TITLE
Adding support for export jobs

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -21,6 +21,7 @@ package com.treasuredata.client;
 import com.google.common.base.Function;
 import com.treasuredata.client.model.TDBulkImportSession;
 import com.treasuredata.client.model.TDDatabase;
+import com.treasuredata.client.model.TDExportJobRequest;
 import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobList;
 import com.treasuredata.client.model.TDJobRequest;
@@ -200,4 +201,6 @@ public interface TDClientApi<ClientImpl>
     void deleteBulkImportSession(String sessionName);
 
     <Result> Result getBulkImportErrorRecords(String sessionName, Function<InputStream, Result> resultStreamHandler);
+
+    String submitExportJob(TDExportJobRequest jobRequest);
 }

--- a/src/main/java/com/treasuredata/client/model/TDExportFileFormatType.java
+++ b/src/main/java/com/treasuredata/client/model/TDExportFileFormatType.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.treasuredata.client.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+
+public enum TDExportFileFormatType
+{
+    TSV_GZ("tsv.gz"),
+    JSONL_GZ("jsonl.gz"),
+    JSON_GZ("json.gz"),
+    JSON_LINE_GZ("json-line.gz");
+
+    private String name;
+
+    private TDExportFileFormatType(String name)
+    {
+        this.name = name;
+    }
+
+    @JsonCreator
+    public static TDExportFileFormatType fromName(String name)
+    {
+        if ("tsv.gz".equals(name)) {
+            return TSV_GZ;
+        }
+        else if ("jsonl.gz".equals(name)) {
+            return JSONL_GZ;
+        }
+        else if ("json.gz".equals(name)) {
+            return JSON_GZ;
+        }
+        else if ("json-line.gz".equals(name)) {
+            return JSON_LINE_GZ;
+        }
+        throw new RuntimeJsonMappingException("Unexpected export file format type");
+    }
+
+    public String getTypeName()
+    {
+        return name;
+    }
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+}

--- a/src/main/java/com/treasuredata/client/model/TDExportJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDExportJobRequest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.treasuredata.client.model;
+
+import java.util.Date;
+import com.google.common.base.Optional;
+
+/**
+ *
+ */
+public class TDExportJobRequest
+{
+    private final String database;
+    private final String table;
+    private final Date from;
+    private final Date to;
+    private final TDExportFileFormatType fileFormat;
+    private final String accessKeyId;
+    private final String secretAccessKey;
+    private final String bucketName;
+    private final String filePrefix;
+    private final Optional<String> poolName;
+
+    public TDExportJobRequest(
+            String database,
+            String table,
+            Date from,
+            Date to,
+            TDExportFileFormatType fileFormat,
+            String accessKeyId,
+            String secretAccessKey,
+            String bucketName,
+            String filePrefix,
+            Optional<String> poolName)
+    {
+        this.database = database;
+        this.table = table;
+        this.from = from;
+        this.to = to;
+        this.fileFormat = fileFormat;
+        this.accessKeyId = accessKeyId;
+        this.secretAccessKey = secretAccessKey;
+        this.bucketName = bucketName;
+        this.filePrefix = filePrefix;
+        this.poolName = poolName;
+    }
+
+    public String getDatabase()
+    {
+        return database;
+    }
+
+    public String getTable()
+    {
+        return table;
+    }
+
+    public Date getFrom()
+    {
+        return from;
+    }
+
+    public Date getTo()
+    {
+        return to;
+    }
+
+    public TDExportFileFormatType getFileFormat()
+    {
+        return fileFormat;
+    }
+
+    public String getAccessKeyId()
+    {
+        return accessKeyId;
+    }
+
+    public String getSecretAccessKey()
+    {
+        return secretAccessKey;
+    }
+
+    public String getBucketName()
+    {
+        return bucketName;
+    }
+
+    public String getFilePrefix()
+    {
+        return filePrefix;
+    }
+
+    public Optional<String> getPoolName()
+    {
+        return poolName;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TDExportJobRequest{" +
+                "database='" + database + '\'' +
+                ", table='" + table + '\'' +
+                ", from=" + (from.getTime() / 1000) +
+                ", to=" + (to.getTime() / 1000) +
+                ", fileFormat='" + fileFormat + '\'' +
+                ", accessKeyId='" + accessKeyId + '\'' +
+                ", bucketName='" + bucketName + '\'' +
+                ", filePrefix='" + filePrefix + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/treasuredata/client/model/TDJob.java
+++ b/src/main/java/com/treasuredata/client/model/TDJob.java
@@ -30,7 +30,7 @@ public class TDJob
 {
     public static enum Type
     {
-        HIVE("hive"), MAPRED("mapred"), PRESTO("presto"), BULKLOAD("bulkload"), UNKNOWN("none");
+        HIVE("hive"), MAPRED("mapred"), PRESTO("presto"), BULKLOAD("bulkload"), EXPORT("export"), UNKNOWN("none");
         private final String type;
 
         private Type(String type)

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -32,6 +32,8 @@ import com.google.common.io.CharStreams;
 import com.treasuredata.client.model.TDBulkImportSession;
 import com.treasuredata.client.model.TDColumn;
 import com.treasuredata.client.model.TDDatabase;
+import com.treasuredata.client.model.TDExportJobRequest;
+import com.treasuredata.client.model.TDExportFileFormatType;
 import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobList;
 import com.treasuredata.client.model.TDJobRequest;
@@ -363,6 +365,28 @@ public class TestTDClient
         String jobId = client.submit(TDJobRequest.newBulkLoad(SAMPLE_DB, "sample_output", config));
         TDJobSummary tdJob = waitJobCompletion(jobId);
         // this job will fail because of lack of parameters for s3 input plugin
+    }
+
+    @Test
+    public void submitExportJob()
+            throws Exception
+    {
+        TDExportJobRequest jobRequest = new TDExportJobRequest(
+                SAMPLE_DB,
+                "sample_output",
+                new Date(0L),
+                new Date(1456522300L * 1000),
+                TDExportFileFormatType.JSONL_GZ,
+                "access key id",
+                "secret access key",
+                "bucket",
+                "prefix/",
+                Optional.<String>absent());
+        client.createDatabaseIfNotExists(SAMPLE_DB);
+        client.createTableIfNotExists(SAMPLE_DB, "sample_output");
+        String jobId = client.submitExportJob(jobRequest);
+        TDJobSummary tdJob = waitJobCompletion(jobId);
+        // this job will do nothing because sample_output table is empty
     }
 
     @Test


### PR DESCRIPTION
This pull-request adds TDClient.submitExportJob method.

TDExportJobRequest.toString doesn't output secretAccessKey for better security.
I used Date class for `from` and `to` fields so that users don't get confused about unit (seconds or milliseconds).
