### PR TITLE
Use enum for TDClientConfig keys

### DIFF
--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -23,24 +23,24 @@ import com.google.common.base.Optional;
 import java.util.Properties;
 
 import static com.treasuredata.client.TDClientConfig.ENV_TD_CLIENT_APIKEY;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_APIKEY;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_API_ENDPOINT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_API_PORT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_CONNECTION_POOL_SIZE;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_CONNECT_TIMEOUT_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_IDLE_TIMEOUT_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PASSOWRD;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_HOST;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_PASSWORD;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_PORT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_USER;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_USESSL;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_LIMIT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MULTIPLIER;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USER;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USESSL;
+import static com.treasuredata.client.TDClientConfig.Type.APIKEY;
+import static com.treasuredata.client.TDClientConfig.Type.API_ENDPOINT;
+import static com.treasuredata.client.TDClientConfig.Type.API_PORT;
+import static com.treasuredata.client.TDClientConfig.Type.CONNECTION_POOL_SIZE;
+import static com.treasuredata.client.TDClientConfig.Type.CONNECT_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.IDLE_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.PASSOWRD;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_HOST;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_PASSWORD;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_PORT;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_USER;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_USESSL;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_INITIAL_INTERVAL_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_LIMIT;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_MAX_INTERVAL_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_MULTIPLIER;
+import static com.treasuredata.client.TDClientConfig.Type.USER;
+import static com.treasuredata.client.TDClientConfig.Type.USESSL;
 import static com.treasuredata.client.TDClientConfig.getTDConfProperties;
 
 /**
@@ -63,14 +63,19 @@ public abstract class AbstractTDClientBuilder<ClientImpl>
     protected int idleTimeoutMillis = 60000;
     protected int connectionPoolSize = 64;
 
+    private static Optional<String> getConfigProperty(Properties p, TDClientConfig.Type key)
+    {
+        return getConfigProperty(p, key.key);
+    }
+
     private static Optional<String> getConfigProperty(Properties p, String key)
     {
         return Optional.fromNullable(p.getProperty(key));
     }
 
-    private static Optional<Integer> getConfigPropertyInt(Properties p, String key)
+    private static Optional<Integer> getConfigPropertyInt(Properties p, TDClientConfig.Type key)
     {
-        String v = p.getProperty(key);
+        String v = p.getProperty(key.key);
         if (v != null) {
             try {
                 return Optional.of(Integer.parseInt(v));
@@ -84,9 +89,9 @@ public abstract class AbstractTDClientBuilder<ClientImpl>
         }
     }
 
-    private static Optional<Double> getConfigPropertyDouble(Properties p, String key)
+    private static Optional<Double> getConfigPropertyDouble(Properties p, TDClientConfig.Type key)
     {
-        String v = p.getProperty(key);
+        String v = p.getProperty(key.key);
         if (v != null) {
             try {
                 return Optional.of(Double.parseDouble(v));
@@ -135,18 +140,18 @@ public abstract class AbstractTDClientBuilder<ClientImpl>
      */
     public AbstractTDClientBuilder<ClientImpl> setProperties(Properties p)
     {
-        this.endpoint = getConfigProperty(p, TD_CLIENT_API_ENDPOINT).or(endpoint);
-        this.port = getConfigPropertyInt(p, TD_CLIENT_API_PORT).or(port);
-        if (p.containsKey(TD_CLIENT_USESSL)) {
-            setUseSSL(Boolean.parseBoolean(p.getProperty(TD_CLIENT_USESSL)));
+        this.endpoint = getConfigProperty(p, API_ENDPOINT).or(endpoint);
+        this.port = getConfigPropertyInt(p, API_PORT).or(port);
+        if (p.containsKey(USESSL.key)) {
+            setUseSSL(Boolean.parseBoolean(p.getProperty(USESSL.key)));
         }
-        this.apiKey = getConfigProperty(p, TD_CLIENT_APIKEY)
+        this.apiKey = getConfigProperty(p, APIKEY)
                 .or(getConfigProperty(p, "apikey"))
                 .or(apiKey);
-        this.user = getConfigProperty(p, TD_CLIENT_USER)
+        this.user = getConfigProperty(p, USER)
                 .or(getConfigProperty(p, "user"))
                 .or(user);
-        this.password = getConfigProperty(p, TD_CLIENT_PASSOWRD)
+        this.password = getConfigProperty(p, PASSOWRD)
                 .or(getConfigProperty(p, "password"))
                 .or(password);
 
@@ -160,11 +165,11 @@ public abstract class AbstractTDClientBuilder<ClientImpl>
         else {
             proxyConfig = new ProxyConfig.ProxyConfigBuilder();
         }
-        Optional<String> proxyHost = getConfigProperty(p, TD_CLIENT_PROXY_HOST);
-        Optional<Integer> proxyPort = getConfigPropertyInt(p, TD_CLIENT_PROXY_PORT);
-        Optional<String> proxyUseSSL = getConfigProperty(p, TD_CLIENT_PROXY_USESSL);
-        Optional<String> proxyUser = getConfigProperty(p, TD_CLIENT_PROXY_USER);
-        Optional<String> proxyPassword = getConfigProperty(p, TD_CLIENT_PROXY_PASSWORD);
+        Optional<String> proxyHost = getConfigProperty(p, PROXY_HOST);
+        Optional<Integer> proxyPort = getConfigPropertyInt(p, PROXY_PORT);
+        Optional<String> proxyUseSSL = getConfigProperty(p, PROXY_USESSL);
+        Optional<String> proxyUser = getConfigProperty(p, PROXY_USER);
+        Optional<String> proxyPassword = getConfigProperty(p, PROXY_PASSWORD);
         if (proxyHost.isPresent()) {
             hasProxy = true;
             proxyConfig.setHost(proxyHost.get());
@@ -188,13 +193,13 @@ public abstract class AbstractTDClientBuilder<ClientImpl>
         this.proxy = Optional.fromNullable(hasProxy ? proxyConfig.createProxyConfig() : null);
 
         // http client parameter
-        this.retryLimit = getConfigPropertyInt(p, TD_CLIENT_RETRY_LIMIT).or(retryLimit);
-        this.retryInitialIntervalMillis = getConfigPropertyInt(p, TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS).or(retryInitialIntervalMillis);
-        this.retryMaxIntervalMillis = getConfigPropertyInt(p, TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS).or(retryMaxIntervalMillis);
-        this.retryMultiplier = getConfigPropertyDouble(p, TD_CLIENT_RETRY_MULTIPLIER).or(retryMultiplier);
-        this.connectTimeoutMillis = getConfigPropertyInt(p, TD_CLIENT_CONNECT_TIMEOUT_MILLIS).or(connectTimeoutMillis);
-        this.idleTimeoutMillis = getConfigPropertyInt(p, TD_CLIENT_IDLE_TIMEOUT_MILLIS).or(idleTimeoutMillis);
-        this.connectionPoolSize = getConfigPropertyInt(p, TD_CLIENT_CONNECTION_POOL_SIZE).or(connectionPoolSize);
+        this.retryLimit = getConfigPropertyInt(p, RETRY_LIMIT).or(retryLimit);
+        this.retryInitialIntervalMillis = getConfigPropertyInt(p, RETRY_INITIAL_INTERVAL_MILLIS).or(retryInitialIntervalMillis);
+        this.retryMaxIntervalMillis = getConfigPropertyInt(p, RETRY_MAX_INTERVAL_MILLIS).or(retryMaxIntervalMillis);
+        this.retryMultiplier = getConfigPropertyDouble(p, RETRY_MULTIPLIER).or(retryMultiplier);
+        this.connectTimeoutMillis = getConfigPropertyInt(p, CONNECT_TIMEOUT_MILLIS).or(connectTimeoutMillis);
+        this.idleTimeoutMillis = getConfigPropertyInt(p, IDLE_TIMEOUT_MILLIS).or(idleTimeoutMillis);
+        this.connectionPoolSize = getConfigPropertyInt(p, CONNECTION_POOL_SIZE).or(connectionPoolSize);
 
         return this;
     }
@@ -283,7 +288,11 @@ public abstract class AbstractTDClientBuilder<ClientImpl>
         return this;
     }
 
-    protected TDClientConfig buildConfig()
+    /**
+     * Build a config object.
+     * @return
+     */
+    public TDClientConfig buildConfig()
     {
         return new TDClientConfig(
                 endpoint,

--- a/src/test/java/com/treasuredata/client/TestTDClientConfig.java
+++ b/src/test/java/com/treasuredata/client/TestTDClientConfig.java
@@ -23,26 +23,27 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_API_ENDPOINT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_API_PORT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_CONNECTION_POOL_SIZE;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_CONNECT_TIMEOUT_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_IDLE_TIMEOUT_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PASSOWRD;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_HOST;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_PASSWORD;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_PORT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_USER;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_PROXY_USESSL;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_LIMIT;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_RETRY_MULTIPLIER;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USER;
-import static com.treasuredata.client.TDClientConfig.TD_CLIENT_USESSL;
+import static com.treasuredata.client.TDClientConfig.Type.API_ENDPOINT;
+import static com.treasuredata.client.TDClientConfig.Type.API_PORT;
+import static com.treasuredata.client.TDClientConfig.Type.CONNECTION_POOL_SIZE;
+import static com.treasuredata.client.TDClientConfig.Type.CONNECT_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.IDLE_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.PASSOWRD;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_HOST;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_PASSWORD;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_PORT;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_USER;
+import static com.treasuredata.client.TDClientConfig.Type.PROXY_USESSL;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_INITIAL_INTERVAL_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_LIMIT;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_MAX_INTERVAL_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.RETRY_MULTIPLIER;
+import static com.treasuredata.client.TDClientConfig.Type.USER;
+import static com.treasuredata.client.TDClientConfig.Type.USESSL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -54,41 +55,41 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("unchecked")
 public class TestTDClientConfig
 {
-    static ImmutableMap<String, Object> m;
+    static ImmutableMap<TDClientConfig.Type, Object> m;
 
     static {
-        ImmutableMap.Builder p = ImmutableMap.<String, Object>builder();
-        p.put(TD_CLIENT_API_ENDPOINT, "api2.treasuredata.com");
-        p.put(TD_CLIENT_API_PORT, 8981);
-        p.put(TD_CLIENT_USESSL, true);
-        p.put(TD_CLIENT_CONNECT_TIMEOUT_MILLIS, 2345);
-        p.put(TD_CLIENT_IDLE_TIMEOUT_MILLIS, 3456);
-        p.put(TD_CLIENT_CONNECTION_POOL_SIZE, 234);
-        p.put(TD_CLIENT_RETRY_LIMIT, 11);
-        p.put(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS, 456);
-        p.put(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS, 10000);
-        p.put(TD_CLIENT_RETRY_MULTIPLIER, 1.5);
-        p.put(TD_CLIENT_USER, "xxxx");
-        p.put(TD_CLIENT_PASSOWRD, "yyyy");
+        ImmutableMap.Builder p = ImmutableMap.<TDClientConfig.Type, Object>builder();
+        p.put(API_ENDPOINT, "api2.treasuredata.com");
+        p.put(API_PORT, 8981);
+        p.put(USESSL, true);
+        p.put(CONNECT_TIMEOUT_MILLIS, 2345);
+        p.put(IDLE_TIMEOUT_MILLIS, 3456);
+        p.put(CONNECTION_POOL_SIZE, 234);
+        p.put(RETRY_LIMIT, 11);
+        p.put(RETRY_INITIAL_INTERVAL_MILLIS, 456);
+        p.put(RETRY_MAX_INTERVAL_MILLIS, 10000);
+        p.put(RETRY_MULTIPLIER, 1.5);
+        p.put(USER, "xxxx");
+        p.put(PASSOWRD, "yyyy");
         m = p.build();
 
-        assertTrue(TDClientConfig.knownProperties.containsAll(m.keySet()));
+        assertTrue(new HashSet(TDClientConfig.knownProperties()).containsAll(m.keySet()));
     }
 
     private void validate(TDClientConfig config)
     {
-        assertEquals(m.get(TD_CLIENT_API_ENDPOINT), config.endpoint);
-        assertEquals(m.get(TD_CLIENT_API_PORT), config.port.get());
-        assertEquals(m.get(TD_CLIENT_USESSL), config.useSSL);
-        assertEquals(m.get(TD_CLIENT_CONNECT_TIMEOUT_MILLIS), config.connectTimeoutMillis);
-        assertEquals(m.get(TD_CLIENT_CONNECTION_POOL_SIZE), config.connectionPoolSize);
-        assertEquals(m.get(TD_CLIENT_IDLE_TIMEOUT_MILLIS), config.idleTimeoutMillis);
-        assertEquals(m.get(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS), config.retryInitialIntervalMillis);
-        assertEquals(m.get(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS), config.retryMaxIntervalMillis);
-        assertEquals((double) m.get(TD_CLIENT_RETRY_MULTIPLIER), config.retryMultiplier, 0.001);
-        assertEquals(m.get(TD_CLIENT_RETRY_LIMIT), config.retryLimit);
-        assertEquals(m.get(TD_CLIENT_USER), config.user.get());
-        assertEquals(m.get(TD_CLIENT_PASSOWRD), config.password.get());
+        assertEquals(m.get(API_ENDPOINT), config.endpoint);
+        assertEquals(m.get(API_PORT), config.port.get());
+        assertEquals(m.get(USESSL), config.useSSL);
+        assertEquals(m.get(CONNECT_TIMEOUT_MILLIS), config.connectTimeoutMillis);
+        assertEquals(m.get(CONNECTION_POOL_SIZE), config.connectionPoolSize);
+        assertEquals(m.get(IDLE_TIMEOUT_MILLIS), config.idleTimeoutMillis);
+        assertEquals(m.get(RETRY_INITIAL_INTERVAL_MILLIS), config.retryInitialIntervalMillis);
+        assertEquals(m.get(RETRY_MAX_INTERVAL_MILLIS), config.retryMaxIntervalMillis);
+        assertEquals((double) m.get(RETRY_MULTIPLIER), config.retryMultiplier, 0.001);
+        assertEquals(m.get(RETRY_LIMIT), config.retryLimit);
+        assertEquals(m.get(USER), config.user.get());
+        assertEquals(m.get(PASSOWRD), config.password.get());
         assertFalse(config.proxy.isPresent());
     }
 
@@ -97,8 +98,8 @@ public class TestTDClientConfig
     {
         // Configuration via Properties object
         Properties p = new Properties();
-        for (Map.Entry<String, Object> e : m.entrySet()) {
-            p.setProperty(e.getKey(), e.getValue().toString());
+        for (Map.Entry<TDClientConfig.Type, Object> e : m.entrySet()) {
+            p.setProperty(e.getKey().key, e.getValue().toString());
         }
         TDClient client = TDClient.newBuilder().setProperties(p).build();
         TDClientConfig config = client.config;
@@ -106,18 +107,18 @@ public class TestTDClientConfig
 
         // Configuration via setters
         TDClientBuilder b = TDClient.newBuilder();
-        b.setEndpoint(m.get(TD_CLIENT_API_ENDPOINT).toString());
-        b.setPort(Integer.parseInt(m.get(TD_CLIENT_API_PORT).toString()));
-        b.setUseSSL(Boolean.parseBoolean(m.get(TD_CLIENT_USESSL).toString()));
-        b.setConnectTimeoutMillis(Integer.parseInt(m.get(TD_CLIENT_CONNECT_TIMEOUT_MILLIS).toString()));
-        b.setConnectionPoolSize(Integer.parseInt(m.get(TD_CLIENT_CONNECTION_POOL_SIZE).toString()));
-        b.setIdleTimeoutMillis(Integer.parseInt(m.get(TD_CLIENT_IDLE_TIMEOUT_MILLIS).toString()));
-        b.setRetryInitialIntervalMillis(Integer.parseInt(m.get(TD_CLIENT_RETRY_INITIAL_INTERVAL_MILLIS).toString()));
-        b.setRetryMaxIntervalMillis(Integer.parseInt(m.get(TD_CLIENT_RETRY_MAX_INTERVAL_MILLIS).toString()));
-        b.setRetryMultiplier(Double.parseDouble(m.get(TD_CLIENT_RETRY_MULTIPLIER).toString()));
-        b.setRetryLimit(Integer.parseInt(m.get(TD_CLIENT_RETRY_LIMIT).toString()));
-        b.setUser(m.get(TD_CLIENT_USER).toString());
-        b.setPassword(m.get(TD_CLIENT_PASSOWRD).toString());
+        b.setEndpoint(m.get(API_ENDPOINT).toString());
+        b.setPort(Integer.parseInt(m.get(API_PORT).toString()));
+        b.setUseSSL(Boolean.parseBoolean(m.get(USESSL).toString()));
+        b.setConnectTimeoutMillis(Integer.parseInt(m.get(CONNECT_TIMEOUT_MILLIS).toString()));
+        b.setConnectionPoolSize(Integer.parseInt(m.get(CONNECTION_POOL_SIZE).toString()));
+        b.setIdleTimeoutMillis(Integer.parseInt(m.get(IDLE_TIMEOUT_MILLIS).toString()));
+        b.setRetryInitialIntervalMillis(Integer.parseInt(m.get(RETRY_INITIAL_INTERVAL_MILLIS).toString()));
+        b.setRetryMaxIntervalMillis(Integer.parseInt(m.get(RETRY_MAX_INTERVAL_MILLIS).toString()));
+        b.setRetryMultiplier(Double.parseDouble(m.get(RETRY_MULTIPLIER).toString()));
+        b.setRetryLimit(Integer.parseInt(m.get(RETRY_LIMIT).toString()));
+        b.setUser(m.get(USER).toString());
+        b.setPassword(m.get(PASSOWRD).toString());
         TDClientConfig config2 = b.build().config;
         validate(config2);
     }
@@ -125,23 +126,23 @@ public class TestTDClientConfig
     @Test
     public void testProxyParam()
     {
-        Map<String, Object> m = new HashMap<String, Object>();
-        m.put(TD_CLIENT_PROXY_HOST, "localhost1");
-        m.put(TD_CLIENT_PROXY_PORT, 8982);
-        m.put(TD_CLIENT_PROXY_USER, "pp");
-        m.put(TD_CLIENT_PROXY_PASSWORD, "xyz");
-        m.put(TD_CLIENT_PROXY_USESSL, true);
+        Map<TDClientConfig.Type, Object> m = new HashMap<TDClientConfig.Type, Object>();
+        m.put(PROXY_HOST, "localhost1");
+        m.put(PROXY_PORT, 8982);
+        m.put(PROXY_USER, "pp");
+        m.put(PROXY_PASSWORD, "xyz");
+        m.put(PROXY_USESSL, true);
         Properties p = new Properties();
-        for (Map.Entry<String, Object> e : m.entrySet()) {
-            p.setProperty(e.getKey(), e.getValue().toString());
+        for (Map.Entry<TDClientConfig.Type, Object> e : m.entrySet()) {
+            p.setProperty(e.getKey().key, e.getValue().toString());
         }
         TDClientConfig config = TDClient.newBuilder().setProperties(p).build().config;
         ProxyConfig proxy = config.proxy.get();
-        assertEquals(m.get(TD_CLIENT_PROXY_HOST), proxy.getHost());
-        assertEquals(m.get(TD_CLIENT_PROXY_PORT), proxy.getPort());
-        assertEquals(m.get(TD_CLIENT_PROXY_USER), proxy.getUser().get());
-        assertEquals(m.get(TD_CLIENT_PROXY_USESSL), proxy.useSSL());
-        assertEquals(m.get(TD_CLIENT_PROXY_PASSWORD), proxy.getPassword().get());
+        assertEquals(m.get(PROXY_HOST), proxy.getHost());
+        assertEquals(m.get(PROXY_PORT), proxy.getPort());
+        assertEquals(m.get(PROXY_USER), proxy.getUser().get());
+        assertEquals(m.get(PROXY_USESSL), proxy.useSSL());
+        assertEquals(m.get(PROXY_PASSWORD), proxy.getPassword().get());
     }
 
     @Test
@@ -172,7 +173,7 @@ public class TestTDClientConfig
     public void readInvalidValue()
     {
         Properties p = new Properties();
-        p.setProperty(TD_CLIENT_API_PORT, "xxxx");
+        p.setProperty(API_PORT.key, "xxxx");
         TDClient.newBuilder().setProperties(p);
     }
 
@@ -180,7 +181,22 @@ public class TestTDClientConfig
     public void readInvalidDoubleValue()
     {
         Properties p = new Properties();
-        p.setProperty(TD_CLIENT_RETRY_MULTIPLIER, "xxx");
+        p.setProperty(RETRY_MULTIPLIER.key, "xxx");
         TDClient.newBuilder().setProperties(p);
+    }
+
+    @Test
+    public void canConvertToProperties()
+    {
+        ProxyConfig.ProxyConfigBuilder pb = new ProxyConfig.ProxyConfigBuilder();
+        pb.setHost("localhost");
+        pb.setPort(8081);
+        pb.setUser("dummy");
+        pb.setPassword("hello");
+        TDClientConfig config = TDClient.newBuilder(false).setProxy(pb.createProxyConfig()).buildConfig();
+        Properties p1 = config.toProperties();
+        TDClientConfig newConfig = TDClient.newBuilder(false).setProperties(p1).buildConfig();
+        Properties p2 = newConfig.toProperties();
+        assertEquals(p1, p2);
     }
 }


### PR DESCRIPTION
For convenience of implementing td-jdbc, which only can pass Properties object. 