### PR TITLE
add scheduled_time param

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -475,6 +475,9 @@ public class TDClient
         if (jobRequest.getTable().isPresent()) {
             queryParam.put("table", jobRequest.getTable().get());
         }
+        if (jobRequest.getScheduledTime().isPresent()) {
+            queryParam.put("scheduled_time", String.valueOf(jobRequest.getScheduledTime().get()));
+        }
 
         if (logger.isDebugEnabled()) {
             logger.debug("submit job: " + jobRequest);

--- a/src/main/java/com/treasuredata/client/model/TDJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequest.java
@@ -35,7 +35,9 @@ public class TDJobRequest
     private final Optional<String> poolName;
     private final Optional<String> table;
     private final Optional<ObjectNode> config;
+    private final Optional<Long> scheduledTime;
 
+    @Deprecated
     public TDJobRequest(String database, TDJob.Type type, String query, TDJob.Priority priority, Optional<String> resultOutput, Optional<Integer> retryLimit, Optional<String> poolName, Optional<String> table, Optional<ObjectNode> config)
     {
         this.database = database;
@@ -47,6 +49,21 @@ public class TDJobRequest
         this.poolName = poolName;
         this.table = table;
         this.config = config;
+        this.scheduledTime = Optional.absent();
+    }
+
+    private TDJobRequest(TDJobRequestBuilder builder)
+    {
+        this.database = builder.getDatabase();
+        this.type = builder.getType();
+        this.query = builder.getQuery();
+        this.priority = builder.getPriority();
+        this.resultOutput = builder.getResultOutput();
+        this.retryLimit = builder.getRetryLimit();
+        this.poolName = builder.getPoolName();
+        this.table = builder.getTable();
+        this.config = builder.getConfig();
+        this.scheduledTime = builder.getScheduledTime();
     }
 
     public static TDJobRequest newPrestoQuery(String database, String query)
@@ -154,6 +171,16 @@ public class TDJobRequest
         return config;
     }
 
+    public Optional<Long> getScheduledTime()
+    {
+        return scheduledTime;
+    }
+
+    static TDJobRequest of(TDJobRequestBuilder builder)
+    {
+        return new TDJobRequest(builder);
+    }
+
     @Override
     public String toString()
     {
@@ -162,9 +189,12 @@ public class TDJobRequest
                 ", type=" + type +
                 ", query='" + query + '\'' +
                 ", priority=" + priority +
+                ", resultOutput=" + resultOutput +
                 ", retryLimit=" + retryLimit +
+                ", poolName=" + poolName +
                 ", table=" + table +
                 ", config=" + config +
+                ", scheduledTime=" + scheduledTime +
                 '}';
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
@@ -32,6 +32,7 @@ public class TDJobRequestBuilder
     private String poolName;
     private Optional<String> table = Optional.absent();
     private Optional<ObjectNode> config = Optional.absent();
+    private Optional<Long> scheduledTime = Optional.absent();
 
     public TDJobRequestBuilder setResultOutput(String result)
     {
@@ -39,10 +40,20 @@ public class TDJobRequestBuilder
         return this;
     }
 
+    public Optional<String> getResultOutput()
+    {
+        return Optional.fromNullable(result);
+    }
+
     public TDJobRequestBuilder setDatabase(String database)
     {
         this.database = database;
         return this;
+    }
+
+    public String getDatabase()
+    {
+        return database;
     }
 
     public TDJobRequestBuilder setType(TDJob.Type type)
@@ -57,10 +68,20 @@ public class TDJobRequestBuilder
         return this;
     }
 
+    public TDJob.Type getType()
+    {
+        return type;
+    }
+
     public TDJobRequestBuilder setQuery(String query)
     {
         this.query = query;
         return this;
+    }
+
+    public String getQuery()
+    {
+        return query;
     }
 
     public TDJobRequestBuilder setPriority(TDJob.Priority priority)
@@ -75,10 +96,20 @@ public class TDJobRequestBuilder
         return this;
     }
 
+    public TDJob.Priority getPriority()
+    {
+        return priority;
+    }
+
     public TDJobRequestBuilder setRetryLimit(int retryLimit)
     {
         this.retryLimit = Optional.of(retryLimit);
         return this;
+    }
+
+    public Optional<Integer> getRetryLimit()
+    {
+        return retryLimit;
     }
 
     public TDJobRequestBuilder setPoolName(String poolName)
@@ -87,10 +118,20 @@ public class TDJobRequestBuilder
         return this;
     }
 
+    public Optional<String> getPoolName()
+    {
+        return Optional.fromNullable(poolName);
+    }
+
     public TDJobRequestBuilder setTable(String table)
     {
         this.table = Optional.of(table);
         return this;
+    }
+
+    public Optional<String> getTable()
+    {
+        return table;
     }
 
     public TDJobRequestBuilder setConfig(ObjectNode config)
@@ -99,8 +140,29 @@ public class TDJobRequestBuilder
         return this;
     }
 
+    public Optional<ObjectNode> getConfig()
+    {
+        return config;
+    }
+
+    public TDJobRequestBuilder setScheduledTime(Long scheduledTime)
+    {
+        return setScheduledTime(Optional.fromNullable(scheduledTime));
+    }
+
+    public TDJobRequestBuilder setScheduledTime(Optional<Long> scheduledTime)
+    {
+        this.scheduledTime = scheduledTime;
+        return this;
+    }
+
+    public Optional<Long> getScheduledTime()
+    {
+        return scheduledTime;
+    }
+
     public TDJobRequest createTDJobRequest()
     {
-        return new TDJobRequest(database, type, query, priority, Optional.fromNullable(result), retryLimit, Optional.fromNullable(poolName), table, config);
+        return TDJobRequest.of(this);
     }
 }

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -38,6 +38,7 @@ import com.treasuredata.client.model.TDExportJobRequest;
 import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobList;
 import com.treasuredata.client.model.TDJobRequest;
+import com.treasuredata.client.model.TDJobRequestBuilder;
 import com.treasuredata.client.model.TDJobSummary;
 import com.treasuredata.client.model.TDPartialDeleteJob;
 import com.treasuredata.client.model.TDResultFormat;
@@ -351,6 +352,40 @@ public class TestTDClient
         String jobId = client.submit(TDJobRequest.newHiveQuery("sample_datasets", "-- td-client-java test\nselect count(*) from nasdaq", null, poolName));
         TDJobSummary tdJob = waitJobCompletion(jobId);
         client.existsTable(SAMPLE_DB, "sample_output");
+    }
+
+    @Test
+    public void submitJobWithScheduledTime()
+            throws Exception
+    {
+        long scheduledTime = 1368080054;
+        TDJobRequest request = new TDJobRequestBuilder()
+                .setType(TDJob.Type.PRESTO)
+                .setDatabase("sample_datasets")
+                .setQuery("select TD_SCHEDULED_TIME()")
+                .setScheduledTime(scheduledTime)
+                .createTDJobRequest();
+        String jobId = client.submit(request);
+        waitJobCompletion(jobId);
+
+        JSONArray array = client.jobResult(jobId, TDResultFormat.JSON, new Function<InputStream, JSONArray>()
+        {
+            @Override
+            public JSONArray apply(InputStream input)
+            {
+                try {
+                    String result = new String(ByteStreams.toByteArray(input), StandardCharsets.UTF_8);
+                    logger.info("result:\n" + result);
+                    return new JSONArray(result);
+                }
+                catch (Exception e) {
+                    throw Throwables.propagate(e);
+                }
+            }
+        });
+
+        assertEquals(1, array.length());
+        assertEquals(scheduledTime, array.getLong(0));
     }
 
     @Test


### PR DESCRIPTION
Also deprecate public `TdJobRequest` constructor as it makes it impractical to add fields to `TdJobRequest` without making breaking changes (i.e. adding arguments to the public constructor).

Preferred way of instantiating a `TdJobRequest` should be through the builder.