### PR TITLE
add support for job domain keys

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -492,6 +492,9 @@ public class TDClient
         if (jobRequest.getScheduledTime().isPresent()) {
             queryParam.put("scheduled_time", String.valueOf(jobRequest.getScheduledTime().get()));
         }
+        if (jobRequest.getDomainKey().isPresent()) {
+            queryParam.put("domain_key", jobRequest.getDomainKey().get());
+        }
 
         if (logger.isDebugEnabled()) {
             logger.debug("submit job: " + jobRequest);

--- a/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
@@ -18,6 +18,7 @@
  */
 package com.treasuredata.client;
 
+import com.google.common.base.Optional;
 import org.eclipse.jetty.http.HttpStatus;
 
 /**
@@ -26,8 +27,22 @@ import org.eclipse.jetty.http.HttpStatus;
 public class TDClientHttpConflictException
         extends TDClientHttpException
 {
+    private final String conflictsWith;
+
     public TDClientHttpConflictException(String errorMessage)
     {
+        this(errorMessage, null);
+    }
+
+    public TDClientHttpConflictException(String errorMessage, String conflictsWith)
+    {
         super(ErrorType.TARGET_ALREADY_EXISTS, errorMessage, HttpStatus.CONFLICT_409);
+
+        this.conflictsWith = conflictsWith;
+    }
+
+    public Optional<String> getConflictsWith()
+    {
+        return Optional.fromNullable(conflictsWith);
     }
 }

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -329,7 +329,8 @@ public class TDHttpClient
                 case HttpStatus.NOT_FOUND_404:
                     throw new TDClientHttpNotFoundException(errorMessage);
                 case HttpStatus.CONFLICT_409:
-                    throw new TDClientHttpConflictException(errorMessage);
+                    String conflictsWith = errorResponse.isPresent() ? parseConflictsWith(errorResponse.get()) : null;
+                    throw new TDClientHttpConflictException(errorMessage, conflictsWith);
                 case HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407:
                     throw new TDClientHttpException(PROXY_AUTHENTICATION_FAILURE, errorMessage, code);
                 case HttpStatus.UNPROCESSABLE_ENTITY_422:
@@ -346,6 +347,19 @@ public class TDHttpClient
         else {
             throw new TDClientHttpException(UNEXPECTED_RESPONSE_CODE, errorMessage, code);
         }
+    }
+
+    private String parseConflictsWith(TDApiErrorMessage errorResponse)
+    {
+        Map<String, Object> details = errorResponse.getDetails();
+        if (details == null) {
+            return null;
+        }
+        Object conflictsWith = details.get("conflicts_with");
+        if (conflictsWith == null) {
+            return null;
+        }
+        return String.valueOf(conflictsWith);
     }
 
     protected static Optional<HttpResponseException> findHttpResponseException(Throwable e)

--- a/src/main/java/com/treasuredata/client/model/TDApiErrorMessage.java
+++ b/src/main/java/com/treasuredata/client/model/TDApiErrorMessage.java
@@ -20,6 +20,9 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
 
 /**
  *
@@ -29,16 +32,27 @@ public class TDApiErrorMessage
     private final String error;
     private final String text;
     private final String severity;
+    private final Map<String, Object> details;
+
+    public TDApiErrorMessage(
+            String error,
+            String text,
+            String severity)
+    {
+        this(error, text, severity, ImmutableMap.<String, Object>of());
+    }
 
     @JsonCreator
     public TDApiErrorMessage(
             @JsonProperty("error") String error,
             @JsonProperty("text") String text,
-            @JsonProperty("severity") String severity)
+            @JsonProperty("severity") String severity,
+            @JsonProperty("details") Map<String, Object> details)
     {
         this.error = error;
         this.text = text;
         this.severity = severity;
+        this.details = details;
     }
 
     public String getError()
@@ -54,6 +68,11 @@ public class TDApiErrorMessage
     public String getSeverity()
     {
         return severity;
+    }
+
+    public Map<String, Object> getDetails()
+    {
+        return details;
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/model/TDJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequest.java
@@ -36,6 +36,7 @@ public class TDJobRequest
     private final Optional<String> table;
     private final Optional<ObjectNode> config;
     private final Optional<Long> scheduledTime;
+    private final Optional<String> domainKey;
 
     @Deprecated
     public TDJobRequest(String database, TDJob.Type type, String query, TDJob.Priority priority, Optional<String> resultOutput, Optional<Integer> retryLimit, Optional<String> poolName, Optional<String> table, Optional<ObjectNode> config)
@@ -50,6 +51,7 @@ public class TDJobRequest
         this.table = table;
         this.config = config;
         this.scheduledTime = Optional.absent();
+        this.domainKey = Optional.absent();
     }
 
     private TDJobRequest(TDJobRequestBuilder builder)
@@ -64,6 +66,7 @@ public class TDJobRequest
         this.table = builder.getTable();
         this.config = builder.getConfig();
         this.scheduledTime = builder.getScheduledTime();
+        this.domainKey = builder.getDomainKey();
     }
 
     public static TDJobRequest newPrestoQuery(String database, String query)
@@ -176,6 +179,11 @@ public class TDJobRequest
         return scheduledTime;
     }
 
+    public Optional<String> getDomainKey()
+    {
+        return domainKey;
+    }
+
     static TDJobRequest of(TDJobRequestBuilder builder)
     {
         return new TDJobRequest(builder);
@@ -195,6 +203,7 @@ public class TDJobRequest
                 ", table=" + table +
                 ", config=" + config +
                 ", scheduledTime=" + scheduledTime +
+                ", domainKey=" + domainKey +
                 '}';
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
@@ -33,6 +33,7 @@ public class TDJobRequestBuilder
     private Optional<String> table = Optional.absent();
     private Optional<ObjectNode> config = Optional.absent();
     private Optional<Long> scheduledTime = Optional.absent();
+    private Optional<String> domainKey = Optional.absent();
 
     public TDJobRequestBuilder setResultOutput(String result)
     {
@@ -159,6 +160,22 @@ public class TDJobRequestBuilder
     public Optional<Long> getScheduledTime()
     {
         return scheduledTime;
+    }
+
+    public Optional<String> getDomainKey()
+    {
+        return domainKey;
+    }
+
+    public TDJobRequestBuilder setDomainKey(Optional<String> domainKey)
+    {
+        this.domainKey = domainKey;
+        return this;
+    }
+
+    public TDJobRequestBuilder setDomainKey(String domainKey)
+    {
+        return setDomainKey(Optional.fromNullable(domainKey));
     }
 
     public TDJobRequest createTDJobRequest()

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -429,8 +429,13 @@ public class TestTDClient
                 .setDomainKey(domainKey)
                 .createTDJobRequest();
 
-        exception.expect(TDClientHttpConflictException.class);
-        client.submit(request2);
+        try {
+            client.submit(request2);
+            fail("Expected " + TDClientHttpConflictException.class.getName());
+        }
+        catch (TDClientHttpConflictException e) {
+            assertThat(e.getConflictsWith(), is(Optional.of(jobId)));
+        }
     }
 
     @Test

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -56,7 +56,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
@@ -83,6 +85,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -99,6 +102,9 @@ import static org.junit.Assert.fail;
  */
 public class TestTDClient
 {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
     private static final Logger logger = LoggerFactory.getLogger(TestTDClient.class);
 
     private static final String SAMPLE_DB = "_tdclient_test";
@@ -399,6 +405,32 @@ public class TestTDClient
 
         assertEquals(1, array.length());
         assertEquals(scheduledTime, array.getLong(0));
+    }
+
+    @Test
+    public void submitJobWithDomainKey()
+            throws Exception
+    {
+        String domainKey = randomDomainKey();
+
+        TDJobRequest request1 = new TDJobRequestBuilder()
+                .setType(TDJob.Type.PRESTO)
+                .setDatabase("sample_datasets")
+                .setQuery("select 1")
+                .setDomainKey(domainKey)
+                .createTDJobRequest();
+        String jobId = client.submit(request1);
+        waitJobCompletion(jobId);
+
+        TDJobRequest request2 = new TDJobRequestBuilder()
+                .setType(TDJob.Type.PRESTO)
+                .setDatabase("sample_datasets")
+                .setQuery("select 1")
+                .setDomainKey(domainKey)
+                .createTDJobRequest();
+
+        exception.expect(TDClientHttpConflictException.class);
+        client.submit(request2);
     }
 
     @Test
@@ -1019,5 +1051,10 @@ public class TestTDClient
                 .setEndpoint(server.getHostName())
                 .setPort(server.getPort())
                 .build();
+    }
+
+    private String randomDomainKey()
+    {
+        return "td-client-java-test-" + UUID.randomUUID();
     }
 }


### PR DESCRIPTION
The domain_key can be used to make job submission idempotent and retryable. The domain_key must be unique across a TD account. The TD rest api returns 409 for job submissions with a domain_key that has already been used.
