### PR TITLE
Upgrade jackson to 2.6.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,31 +119,31 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.7</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.7</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.7</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.7</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-json-org</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
For using td-client with scala, we cannot use jackson 2.6.2 because of a class binding bug:
https://github.com/FasterXML/jackson-module-scala
At least we need to use 2.6.5 or higher