### PR TITLE
use jetty-client 9.3.11.v20160721

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
-      <version>9.2.2.v20140723</version>
+      <version>9.3.11.v20160721</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- Includes a fix for a http proxying bug that manifested with squid 3.1:
  https://bugs.eclipse.org/bugs/show_bug.cgi?id=475546
- Includes support for HTTPS forward proxies, which means that the
  `useSSL` flag will now actually be respected:
  https://github.com/eclipse/jetty.project/issues/416
