### PR TITLE
restore support for old apikeys

### DIFF
--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -92,7 +92,7 @@ public class TDHttpClient
     private static final Logger logger = LoggerFactory.getLogger(TDHttpClient.class);
 
     // A regex pattern that matches a TD1 apikey without the "TD1 " prefix.
-    private static final Pattern NAKED_TD1_KEY_PATTERN = Pattern.compile("^[1-9][0-9]*/[a-f0-9]{40}$");
+    private static final Pattern NAKED_TD1_KEY_PATTERN = Pattern.compile("^(?:[1-9][0-9]*/)?[a-f0-9]{40}$");
 
     protected final TDClientConfig config;
     private final HttpClient httpClient;

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -24,6 +24,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -1262,6 +1263,25 @@ public class TestTDClient
         String body = recordedRequest.getBody().readUtf8();
         assertThat(body, is(expectedPayload));
         assertThat(recordedRequest.getPath(), is(expectedPath));
+    }
+
+    @Test
+    public void legacyApikeyMocked()
+            throws Exception
+    {
+        String apikey = Strings.repeat("a", 40);
+        client = mockClient().withApiKey(apikey);
+
+        server.enqueue(new MockResponse());
+
+        client.killJob("4711");
+
+        assertThat(server.getRequestCount(), is(1));
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest.getPath(), is("/v3/job/kill/4711"));
+        assertThat(recordedRequest.getHeader("Authorization"), is("TD1 " + apikey));
+
     }
 
     @Test


### PR DESCRIPTION
Supposedly some old apikeys do not have a `account-id/` prefix.
