### PR TITLE
Upgrade to msgpack-java 0.8.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>msgpack-core</artifactId>
-      <version>0.8.8</version>
+      <version>0.8.10</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Found unpackString bug in msgpack-core https://github.com/msgpack/msgpack-java/pull/387.  But td-client-java never uses unpackString, so this upgrade is only for future safety. 