### PR TITLE
Handle 429 Too Many Requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,20 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.exparity</groupId>
+      <artifactId>hamcrest-date</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.9.4</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
@@ -36,7 +36,7 @@ public class TDClientHttpConflictException
 
     public TDClientHttpConflictException(String errorMessage, String conflictsWith)
     {
-        super(ErrorType.TARGET_ALREADY_EXISTS, errorMessage, HttpStatus.CONFLICT_409);
+        super(ErrorType.TARGET_ALREADY_EXISTS, errorMessage, HttpStatus.CONFLICT_409, null);
 
         this.conflictsWith = conflictsWith;
     }

--- a/src/main/java/com/treasuredata/client/TDClientHttpException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpException.java
@@ -18,6 +18,10 @@
  */
 package com.treasuredata.client;
 
+import com.google.common.base.Optional;
+
+import java.util.Date;
+
 /**
  * Exception class for reporting http server status code
  */
@@ -26,14 +30,22 @@ public class TDClientHttpException
 {
     private final int statusCode;
 
-    public TDClientHttpException(ErrorType errorType, String message, int statusCode)
+    private final Date retryAfter;
+
+    public TDClientHttpException(ErrorType errorType, String message, int statusCode, Date retryAfter)
     {
         super(errorType, message);
         this.statusCode = statusCode;
+        this.retryAfter = retryAfter;
     }
 
     public int getStatusCode()
     {
         return statusCode;
+    }
+
+    public Optional<Date> getRetryAfter()
+    {
+        return Optional.fromNullable(retryAfter);
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientHttpException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpException.java
@@ -30,13 +30,13 @@ public class TDClientHttpException
 {
     private final int statusCode;
 
-    private final Date retryAfter;
+    private final long retryAfter;
 
     public TDClientHttpException(ErrorType errorType, String message, int statusCode, Date retryAfter)
     {
         super(errorType, message);
         this.statusCode = statusCode;
-        this.retryAfter = retryAfter;
+        this.retryAfter = retryAfter == null ? -1 : retryAfter.getTime();
     }
 
     public int getStatusCode()
@@ -46,6 +46,11 @@ public class TDClientHttpException
 
     public Optional<Date> getRetryAfter()
     {
-        return Optional.fromNullable(retryAfter);
+        if (retryAfter == -1) {
+            return Optional.absent();
+        }
+        else {
+            return Optional.of(new Date(retryAfter));
+        }
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientHttpNotFoundException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpNotFoundException.java
@@ -28,6 +28,6 @@ public class TDClientHttpNotFoundException
 {
     public TDClientHttpNotFoundException(String message)
     {
-        super(ErrorType.TARGET_NOT_FOUND, message, HttpStatus.NOT_FOUND_404);
+        super(ErrorType.TARGET_NOT_FOUND, message, HttpStatus.NOT_FOUND_404, null);
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientHttpTooManyRequestsException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpTooManyRequestsException.java
@@ -1,0 +1,26 @@
+package com.treasuredata.client;
+
+import com.google.common.base.Optional;
+
+/**
+ * 429 Too Many Requests error (i.e., rate limited).
+ */
+
+public class TDClientHttpTooManyRequestsException
+        extends TDClientHttpException
+{
+    public static final int TOO_MANY_REQUESTS_429 = 429;
+
+    private final Optional<Long> retryAfterSeconds;
+
+    public TDClientHttpTooManyRequestsException(String errorMessage, Optional<Long> retryAfterSeconds)
+    {
+        super(ErrorType.CLIENT_ERROR, errorMessage, TOO_MANY_REQUESTS_429);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public Optional<Long> getRetryAfterSeconds()
+    {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/treasuredata/client/TDClientHttpTooManyRequestsException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpTooManyRequestsException.java
@@ -1,6 +1,6 @@
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
+import java.util.Date;
 
 /**
  * 429 Too Many Requests error (i.e., rate limited).
@@ -11,16 +11,8 @@ public class TDClientHttpTooManyRequestsException
 {
     public static final int TOO_MANY_REQUESTS_429 = 429;
 
-    private final Optional<Long> retryAfterSeconds;
-
-    public TDClientHttpTooManyRequestsException(String errorMessage, Optional<Long> retryAfterSeconds)
+    public TDClientHttpTooManyRequestsException(String errorMessage, Date retryAfter)
     {
-        super(ErrorType.CLIENT_ERROR, errorMessage, TOO_MANY_REQUESTS_429);
-        this.retryAfterSeconds = retryAfterSeconds;
-    }
-
-    public Optional<Long> getRetryAfterSeconds()
-    {
-        return retryAfterSeconds;
+        super(ErrorType.CLIENT_ERROR, errorMessage, TOO_MANY_REQUESTS_429, retryAfter);
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientHttpUnauthorizedException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpUnauthorizedException.java
@@ -26,6 +26,6 @@ public class TDClientHttpUnauthorizedException
 {
     public TDClientHttpUnauthorizedException(String errorMessage)
     {
-        super(ErrorType.AUTHENTICATION_FAILURE, errorMessage, 401);
+        super(ErrorType.AUTHENTICATION_FAILURE, errorMessage, 401, null);
     }
 }

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -496,7 +496,7 @@ public class TDHttpClient
             return new Date(now + TimeUnit.SECONDS.toMillis(retryAfterSeconds));
         }
         catch (NumberFormatException e) {
-            // Then try parsing
+            // Then try parsing as a HTTP-date
             try {
                 return HTTP_DATE_FORMAT.get().parse(retryAfter);
             }

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -377,7 +377,7 @@ public class TDHttpClient
                     if (responseError.isPresent()) {
                         HttpResponseException re = responseError.get();
                         int code = re.getResponse().getStatus();
-                        throw handleHttpResponseError(apiRequest.getPath(), code, new byte[] {}, response);
+                        throw handleHttpResponseError(apiRequest.getPath(), code, new byte[] {}, re.getResponse());
                     }
                     else {
                         if (e.getCause() instanceof EOFException) {

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -84,7 +84,6 @@ import static com.treasuredata.client.TDClientException.ErrorType.PROXY_AUTHENTI
 import static com.treasuredata.client.TDClientException.ErrorType.SERVER_ERROR;
 import static com.treasuredata.client.TDClientException.ErrorType.UNEXPECTED_RESPONSE_CODE;
 import static com.treasuredata.client.TDClientHttpTooManyRequestsException.TOO_MANY_REQUESTS_429;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * An extension of Jetty HttpClient with request retry handler


### PR DESCRIPTION
The TD API returns 429 with a `Retry-After` header when rate limiting requests.

Respect the `Retry-After` value when retrying and also propagate the the value to the user in a new `TDClientHttpTooManyRequestsException` when the configured retry has been exceeded.
