### PR TITLE
Configure request timeout

### DIFF
--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -37,6 +37,7 @@ import static com.treasuredata.client.TDClientConfig.Type.PROXY_PASSWORD;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_PORT;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_USER;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_USESSL;
+import static com.treasuredata.client.TDClientConfig.Type.REQUEST_TIMEOUT_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_INITIAL_INTERVAL_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_LIMIT;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_MAX_INTERVAL_MILLIS;
@@ -63,6 +64,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
     protected double retryMultiplier = 2.0;
     protected int connectTimeoutMillis = 15000;
     protected int idleTimeoutMillis = 60000;
+    protected int requestTimeoutMillis = 0;
     protected int connectionPoolSize = 64;
     protected Multimap<String, String> headers = ImmutableMultimap.of();
     protected Optional<Integer> requestBufferSize = Optional.absent();
@@ -234,6 +236,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         this.retryMultiplier = getConfigPropertyDouble(p, RETRY_MULTIPLIER).or(retryMultiplier);
         this.connectTimeoutMillis = getConfigPropertyInt(p, CONNECT_TIMEOUT_MILLIS).or(connectTimeoutMillis);
         this.idleTimeoutMillis = getConfigPropertyInt(p, IDLE_TIMEOUT_MILLIS).or(idleTimeoutMillis);
+        this.requestTimeoutMillis = getConfigPropertyInt(p, REQUEST_TIMEOUT_MILLIS).or(requestTimeoutMillis);
         this.connectionPoolSize = getConfigPropertyInt(p, CONNECTION_POOL_SIZE).or(connectionPoolSize);
 
         return self();
@@ -317,6 +320,12 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         return self();
     }
 
+    public BuilderImpl setRequestTimeoutMillis(int requestTimeoutMillis)
+    {
+        this.requestTimeoutMillis = requestTimeoutMillis;
+        return self();
+    }
+
     public BuilderImpl setConnectionPoolSize(int connectionPoolSize)
     {
         this.connectionPoolSize = connectionPoolSize;
@@ -361,6 +370,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
                 retryMultiplier,
                 connectTimeoutMillis,
                 idleTimeoutMillis,
+                requestTimeoutMillis,
                 connectionPoolSize,
                 headers,
                 requestBufferSize,

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -59,6 +59,7 @@ public class TDClientConfig
         RETRY_MULTIPLIER("td.client.retry.multiplier", "retry interval multiplier"),
         CONNECT_TIMEOUT_MILLIS("td.client.connect-timeout", "connection timeout before reaching the API"),
         IDLE_TIMEOUT_MILLIS("td.client.idle-timeout", "idle connection timeout when no data is coming from API"),
+        REQUEST_TIMEOUT_MILLIS("td.client.request-timeout", "timeout during executing a request"),
         CONNECTION_POOL_SIZE("td.client.connection-pool-size", "connection pool size"),
         REQUEST_BUFFER_SIZE("td.client.request-buffer-size", "request buffer size"),
         RESPONSE_BUFFER_SIZE("td.client.response-buffer-size", "response buffer size"),
@@ -103,6 +104,7 @@ public class TDClientConfig
     public final double retryMultiplier;
     public final int connectTimeoutMillis;
     public final int idleTimeoutMillis;
+    public final int requestTimeoutMillis;
     public final int connectionPoolSize;
     public final Multimap<String, String> headers;
     public final Optional<Integer> requestBufferSize;
@@ -123,6 +125,7 @@ public class TDClientConfig
             double retryMultiplier,
             int connectTimeoutMillis,
             int idleTimeoutMillis,
+            int requestTimeoutMillis,
             int connectionPoolSize,
             Multimap<String, String> headers,
             Optional<Integer> requestBufferSize,
@@ -141,6 +144,7 @@ public class TDClientConfig
         this.retryMultiplier = retryMultiplier;
         this.connectTimeoutMillis = connectTimeoutMillis;
         this.idleTimeoutMillis = idleTimeoutMillis;
+        this.requestTimeoutMillis = requestTimeoutMillis;
         this.connectionPoolSize = connectionPoolSize;
         this.headers = headers;
         this.requestBufferSize = requestBufferSize;
@@ -168,6 +172,7 @@ public class TDClientConfig
                 retryMultiplier,
                 connectTimeoutMillis,
                 idleTimeoutMillis,
+                requestTimeoutMillis,
                 connectionPoolSize,
                 headers,
                 requestBufferSize,
@@ -220,6 +225,7 @@ public class TDClientConfig
         saveProperty(p, Type.RETRY_MAX_INTERVAL_MILLIS, retryMaxIntervalMillis);
         saveProperty(p, Type.RETRY_MULTIPLIER, retryMultiplier);
         saveProperty(p, Type.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis);
+        saveProperty(p, Type.REQUEST_TIMEOUT_MILLIS, requestTimeoutMillis);
         saveProperty(p, Type.CONNECTION_POOL_SIZE, connectionPoolSize);
         saveProperty(p, Type.REQUEST_BUFFER_SIZE, requestBufferSize);
         saveProperty(p, Type.RESPONSE_BUFFER_SIZE, responseBufferSize);

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -264,7 +264,8 @@ public class TDHttpClient
                 .agent(getClientName())
                 .scheme(config.useSSL ? "https" : "http")
                 .method(apiRequest.getMethod())
-                .header(HttpHeader.DATE, dateHeader);
+                .header(HttpHeader.DATE, dateHeader)
+                .timeout(config.requestTimeoutMillis, TimeUnit.MILLISECONDS);
 
         request = setTDAuthHeaders(request, dateHeader);
 

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -177,10 +177,41 @@ public class TestServerFailures
     }
 
     @Test
-    public void handleTimeoutTest()
+    public void handleIdleTimeoutTest()
             throws Exception
     {
-        logger.warn("Start request retry tests on timeout exception");
+        logger.warn("Start request retry tests on idle timeout exception");
+        handleTimeoutTest(TDClient
+                .newBuilder()
+                .setEndpoint("localhost")
+                .setUseSSL(false)
+                .setPort(port)
+                .setIdleTimeoutMillis(100)
+                .setRetryLimit(1)
+                .buildConfig()
+        );
+
+    }
+
+    @Test
+    public void handleRequestTimeoutTest()
+            throws Exception
+    {
+        logger.warn("Start request retry tests on request timeout exception");
+        handleTimeoutTest(TDClient
+                .newBuilder()
+                .setEndpoint("localhost")
+                .setUseSSL(false)
+                .setPort(port)
+                .setRequestTimeoutMillis(100)
+                .setRetryLimit(1)
+                .buildConfig()
+        );
+    }
+
+    private void handleTimeoutTest(TDClientConfig config)
+        throws Exception
+    {
         final AtomicInteger accessCount = new AtomicInteger(0);
 
         server.setHandler(new AbstractHandler()
@@ -205,15 +236,7 @@ public class TestServerFailures
         });
         startServer();
 
-        TDClient client = TDClient
-                .newBuilder()
-                .setEndpoint("localhost")
-                .setUseSSL(false)
-                .setPort(port)
-                .setIdleTimeoutMillis(100)
-                .setRetryLimit(1)
-                .build();
-
+        TDClient client = new TDClient(config);
         client.serverStatus();
         assertEquals(2, accessCount.get());
     }


### PR DESCRIPTION
My application was waiting for td-client and the control didn't return from td-client. It looks like a jetty client v9.2 bug because it was waiting to get a connection from the connection pool. But, just in case, it's better to customize a request timeout as one of td-client parameters.

The following is a part of my application thread dump:

```
 "main" prio=10 tid=0x00007f51d0011000 nid=0x5460 waiting on condition [0x00007f51d8d1b000]
    java.lang.Thread.State: WAITING (parking)
       at sun.misc.Unsafe.park(Native Method)
       - parking to wait for  <0x00000007ba9c2388> (a java.util.concurrent.CountDownLatch$Sync)
       at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
       at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:834)
       at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:994)
       at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1303)
       at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:236)
       at org.eclipse.jetty.client.util.FutureResponseListener.get(FutureResponseListener.java:100)
       at org.eclipse.jetty.client.HttpRequest.send(HttpRequest.java:639)
... ...
```
