### PR TITLE
Avoid possible annotation name conflict

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -496,20 +496,6 @@ public class TDClient
         doPost(buildUrl("/v3/table/swap", databaseName, tableName1, tableName2));
     }
 
-    private TDTable getTable(String databaseName, String tableName)
-    {
-        checkNotNull(databaseName, "databaseName is null");
-        checkNotNull(tableName, "tableName is null");
-
-        // TODO This should be improved via v4 api
-        for (TDTable table : listTables(databaseName)) {
-            if (table.getName().equals(tableName)) {
-                return table;
-            }
-        }
-        throw new TDClientException(TDClientException.ErrorType.TARGET_NOT_FOUND, String.format("Table %s is not found", tableName));
-    }
-
     @Override
     public void updateTableSchema(String databaseName, String tableName, List<TDColumn> newSchema)
     {

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.io.ByteStreams;
 import com.treasuredata.client.impl.ProxyAuthResult;
+import com.treasuredata.client.model.JsonCollectionRootName;
 import com.treasuredata.client.model.TDApiErrorMessage;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
@@ -630,7 +631,13 @@ public class TDHttpClient
     {
         ObjectReader reader = objectMapper.readerFor(type);
         if (type.getContentType() != null) {
-            JsonRootName rootName = type.getContentType().getRawClass().getAnnotation(JsonRootName.class);
+            JsonCollectionRootName rootName = type.getContentType().getRawClass().getAnnotation(JsonCollectionRootName.class);
+            if (rootName != null) {
+                reader = reader.withRootName(rootName.value());
+            }
+        }
+        else {
+            JsonRootName rootName = type.getRawClass().getAnnotation(JsonRootName.class);
             if (rootName != null) {
                 reader = reader.withRootName(rootName.value());
             }

--- a/src/main/java/com/treasuredata/client/model/JsonCollectionRootName.java
+++ b/src/main/java/com/treasuredata/client/model/JsonCollectionRootName.java
@@ -1,0 +1,18 @@
+package com.treasuredata.client.model;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotation
+public @interface JsonCollectionRootName
+{
+    String value();
+
+    String namespace() default "";
+}

--- a/src/main/java/com/treasuredata/client/model/TDBulkImportSession.java
+++ b/src/main/java/com/treasuredata/client/model/TDBulkImportSession.java
@@ -20,9 +20,8 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
 
-@JsonRootName(value = "bulk_imports")
+@JsonCollectionRootName(value = "bulk_imports")
 public class TDBulkImportSession
 {
     public static enum ImportStatus

--- a/src/main/java/com/treasuredata/client/model/TDDatabase.java
+++ b/src/main/java/com/treasuredata/client/model/TDDatabase.java
@@ -20,11 +20,10 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
-@JsonRootName(value = "databases")
+@JsonCollectionRootName(value = "databases")
 public class TDDatabase
 {
     private final String name;

--- a/src/main/java/com/treasuredata/client/model/TDSavedQuery.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQuery.java
@@ -19,12 +19,11 @@
 package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  *
  */
-@JsonRootName(value = "schedules")
+@JsonCollectionRootName(value = "schedules")
 public class TDSavedQuery
 {
     public static TDSavedQueryBuilder newBuilder(


### PR DESCRIPTION
This is followup of #81. At an extension of this library could have {{@JsonRootName}} for non list field. To prevent possible name conflict on {{@JsonRootName}}, it would be safe to use separate annotation for list field.