### PR TITLE
Add support for result_connection_id and result_connection_settings

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -36,6 +36,7 @@ import com.treasuredata.client.model.TDBulkImportSession;
 import com.treasuredata.client.model.TDBulkLoadSessionStartRequest;
 import com.treasuredata.client.model.TDBulkLoadSessionStartResult;
 import com.treasuredata.client.model.TDColumn;
+import com.treasuredata.client.model.TDConnectionLookupResult;
 import com.treasuredata.client.model.TDDatabase;
 import com.treasuredata.client.model.TDExportJobRequest;
 import com.treasuredata.client.model.TDJob;
@@ -551,6 +552,12 @@ public class TDClient
         if (jobRequest.getDomainKey().isPresent()) {
             queryParam.put("domain_key", jobRequest.getDomainKey().get());
         }
+        if (jobRequest.getResultConnectionId().isPresent()) {
+            queryParam.put("result_connection_id", String.valueOf(jobRequest.getResultConnectionId().get()));
+        }
+        if (jobRequest.getResultConnectionSettings().isPresent()) {
+            queryParam.put("result_connection_settings", jobRequest.getResultConnectionSettings().get());
+        }
 
         if (logger.isDebugEnabled()) {
             logger.debug("submit job: " + jobRequest);
@@ -911,5 +918,11 @@ public class TDClient
         return doPost(buildUrl("/v3/bulk_loads", name, "jobs"),
                 queryParams, Optional.of(payload),
                 TDBulkLoadSessionStartResult.class);
+    }
+
+    @Override
+    public long lookupConnection(String name)
+    {
+        return doGet(buildUrl("/v3/connections/lookup?name=" + urlPathSegmentEscaper().escape(name)), TDConnectionLookupResult.class).getId();
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -345,4 +345,6 @@ public interface TDClientApi<ClientImpl>
      * @return job id
      */
     TDBulkLoadSessionStartResult startBulkLoadSession(String name, TDBulkLoadSessionStartRequest request);
+
+    long lookupConnection(String name);
 }

--- a/src/main/java/com/treasuredata/client/model/TDConnectionLookupResult.java
+++ b/src/main/java/com/treasuredata/client/model/TDConnectionLookupResult.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.treasuredata.client.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ *
+ */
+public class TDConnectionLookupResult
+{
+    private final long id;
+
+    public TDConnectionLookupResult(@JsonProperty("id") long id)
+    {
+        this.id = id;
+    }
+
+    public long getId()
+    {
+        return id;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TDConnectionLookupResult{" +
+                "id='" + id + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/treasuredata/client/model/TDJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequest.java
@@ -37,6 +37,8 @@ public class TDJobRequest
     private final Optional<ObjectNode> config;
     private final Optional<Long> scheduledTime;
     private final Optional<String> domainKey;
+    private final Optional<Long> resultConnectionId;
+    private final Optional<String> resultConnectionSettings;
 
     @Deprecated
     public TDJobRequest(String database, TDJob.Type type, String query, TDJob.Priority priority, Optional<String> resultOutput, Optional<Integer> retryLimit, Optional<String> poolName, Optional<String> table, Optional<ObjectNode> config)
@@ -52,6 +54,8 @@ public class TDJobRequest
         this.config = config;
         this.scheduledTime = Optional.absent();
         this.domainKey = Optional.absent();
+        this.resultConnectionId = Optional.absent();
+        this.resultConnectionSettings = Optional.absent();
     }
 
     private TDJobRequest(TDJobRequestBuilder builder)
@@ -67,6 +71,8 @@ public class TDJobRequest
         this.config = builder.getConfig();
         this.scheduledTime = builder.getScheduledTime();
         this.domainKey = builder.getDomainKey();
+        this.resultConnectionId = builder.getResultConnectionId();
+        this.resultConnectionSettings = builder.getResultConnectionSettings();
     }
 
     public static TDJobRequest newPrestoQuery(String database, String query)
@@ -214,6 +220,16 @@ public class TDJobRequest
         return domainKey;
     }
 
+    public Optional<Long> getResultConnectionId()
+    {
+        return resultConnectionId;
+    }
+
+    public Optional<String> getResultConnectionSettings()
+    {
+        return resultConnectionSettings;
+    }
+
     static TDJobRequest of(TDJobRequestBuilder builder)
     {
         return new TDJobRequest(builder);
@@ -234,6 +250,8 @@ public class TDJobRequest
                 ", config=" + config +
                 ", scheduledTime=" + scheduledTime +
                 ", domainKey=" + domainKey +
+                ", resultConnectionId=" + resultConnectionId +
+                ", resultConnectionSettings=" + resultConnectionSettings +
                 '}';
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
@@ -34,6 +34,8 @@ public class TDJobRequestBuilder
     private Optional<ObjectNode> config = Optional.absent();
     private Optional<Long> scheduledTime = Optional.absent();
     private Optional<String> domainKey = Optional.absent();
+    private Optional<Long> resultConnectionId = Optional.absent();
+    private Optional<String> resultConnectionSettings = Optional.absent();
 
     public TDJobRequestBuilder setResultOutput(String result)
     {
@@ -176,6 +178,38 @@ public class TDJobRequestBuilder
     public TDJobRequestBuilder setDomainKey(String domainKey)
     {
         return setDomainKey(Optional.fromNullable(domainKey));
+    }
+
+    public Optional<Long> getResultConnectionId()
+    {
+        return resultConnectionId;
+    }
+
+    public TDJobRequestBuilder setResultConnectionId(Optional<Long> resultConnectionId)
+    {
+        this.resultConnectionId = resultConnectionId;
+        return this;
+    }
+
+    public TDJobRequestBuilder setResultConnectionId(long resultConnectionId)
+    {
+        return setResultConnectionId(Optional.of(resultConnectionId));
+    }
+
+    public Optional<String> getResultConnectionSettings()
+    {
+        return resultConnectionSettings;
+    }
+
+    public TDJobRequestBuilder setResultConnectionSettings(Optional<String> resultConnectionSettings)
+    {
+        this.resultConnectionSettings = resultConnectionSettings;
+        return this;
+    }
+
+    public TDJobRequestBuilder setResultConnectionSettings(String resultConnectionSettings)
+    {
+        return setResultConnectionSettings(Optional.fromNullable(resultConnectionSettings));
     }
 
     public TDJobRequest createTDJobRequest()


### PR DESCRIPTION
A new release of API supports result_connection_id and
result_connection_settings when issuing a job. There is another REST API
to lookup connection id by name.