### PR TITLE
Use OkHttp 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 *.iml
 lib
 dependency-reduced-pom.xml
+*~

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+Release 0.8.0 - 2017-11-02
+ - [NOTICE] From this version, td-client-java requires Java 8
+ - Using OkHttp as an internal http client instead of jetty-client 9.2.x. This reduces the number of dependencies.
+ - Added TDHttpResponseHandler to customize request/response handling
+ - Deprecated some config parameters (requestTimeout, idleTimeout, response/requestBufferSize, maxContentLength), and add readTimeout.
+
 Release 0.7.41 - 2017-08-04
   - Change TDClient#appendTableSchema to not send column alias for append-schema API [#97](https://github.com/treasure-data/td-client-java/pull/97)
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ With this client, you can:
  - retrieve query results
  - check the information of databases and tables
 
-td-client-java is built for Java 1.7 or higher, and licensed under Apache License Version 2.0.
+Since td-client-java 0.8.0, it requires Java 1.8 or higher. For Java7, use td-client-java-0.7.x.
+
+td-client-java is licensed under Apache License Version 2.0.
 
 ## Download
 
-You can download a jar file (td-client-java-(version)-jar-with-dependencies.jar) from here: http://central.maven.org/maven2/com/treasuredata/client/td-client
+You can download a jar file (td-client-java-(version)-shade.jar) from here: http://central.maven.org/maven2/com/treasuredata/client/td-client
 
-For the information of the older versions, see <https://github.com/treasure-data/td-client-java/tree/0.5.x>.
+For the information of the older versions, see <https://github.com/treasure-data/td-client-java/tree/0.7.x>.
 
 - [Release Notes](CHANGES.txt)
-
 
 ### For Maven Users
 
@@ -38,26 +39,21 @@ Use the following dependency settings:
 <dependency>
   <groupId>ch.qos.logback</groupId>
   <artifactId>logback-classic</artifactId>
-  <version>1.1.3</version>
+  <version>1.2.3</version>
 </dependency>
 ```
 
 #### Standalone jar
-td-client-java uses jetty-client 9.2.2.v20140723 to support Java7.
-If you are using an older (or non-compatible) version of jetty in your project, use `td-client-(version)-jar-with-dependencies.jar`
-to avoid class name conflict:
+td-client-java provides a standalone jar, which include all of the dependencies into a single jar file:
 
 ```
 <dependency>
   <groupId>com.treasuredata.client</groupId>
   <artifactId>td-client</artifactId>
   <version>(version)</version>
-  <classifier>jar-with-dependencies</classifier>
+  <classifier>shade</classifier>
 </dependency>
 ```
-
-td-client-(version)-jar-with-dependencies.jar renames `org.eclipse.jetty` package into `com.treasuredata.client.jetty922`
-so that you can use td-client-java and any version of jetty at the same time.
 
 ## Usage
 
@@ -221,7 +217,7 @@ TDClient client = TDClient.newBuilder().setProperties(prop).build();
 |`td.client.retry.max-interval` | 60000 | (optional) max retry interval |
 |`td.client.retry.multiplier` | 2.0 | (optional) retry interval multiplier |
 |`td.client.connect-timeout` | 15000 | (optional) connection timeout before reaching the API |
-|`td.client.idle-timeout` | 60000 | (optional) idle connection timeout when no data is coming from API |
+|`td.client.read-timeout` | 20000 | (optional) timeout when no data is coming from API |
 |`td.client.connection-pool-size` | 64 | (optional) Connection pool size|
 |`td.client.endpoint` | `api.treasuredata.com` | (optional) TD REST API endpoint name |
 |`td.client.port` | 80 for non-SSL, 443 for SSL connection | (optional) TD API port number |
@@ -258,5 +254,3 @@ $ sbt "sonatypeReleaseAll com.treasuredata"
 ```
 
 See also https://github.com/xerial/sbt-sonatype#publishing-maven-projects to use `sbt sonatypeReleaseAll` command.
-
-

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -4,4 +4,6 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
 <suppressions>
 	<suppress files="[/\\]target[/\\]" checks=".*"/>
+	<suppress files="HttpStatus.java" checks=".*"/>
 </suppressions>
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: openjdk7
+    version: openjdk8
 
 test:
   override:

--- a/pom.xml
+++ b/pom.xml
@@ -226,13 +226,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.targetJdk>1.7</project.build.targetJdk>
+    <project.build.targetJdk>1.8</project.build.targetJdk>
     <project.build.jvmsize>512m</project.build.jvmsize>
     <project.test.fork-mode>once</project.test.fork-mode>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>td-client</artifactId>
   <name>Treasure Data Client for Java</name>
   <description>Treasure Data Client for Java.</description>
-  <version>0.7.42-SNAPSHOT</version>
+  <version>0.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/treasure-data/td-client-java</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,37 +114,37 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>21.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.7</version>
+      <version>2.8.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.7</version>
+      <version>2.8.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.6.7</version>
+      <version>2.8.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.6.7</version>
+      <version>2.8.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-json-org</artifactId>
-      <version>2.6.7</version>
+      <version>2.8.1</version>
     </dependency>
 
     <dependency>
@@ -253,7 +253,7 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.7.0</version>
         <configuration>
           <source>${project.build.targetJdk}</source>
           <target>${project.build.targetJdk}</target>
@@ -267,7 +267,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.2</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -275,14 +275,19 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+	      <artifactSet>
+                <includes>
+                  <include>org.eclipse.jetty:*</include>
+                </includes>
+              </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>org.eclipse.jetty</pattern>
                   <shadedPattern>com.treasuredata.client.jetty922</shadedPattern>
-                </relocation>
+		</relocation>
               </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+              <shadedClassifierName>shade</shadedClassifierName>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -282,17 +282,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-	      <artifactSet>
-                <includes>
-                  <include>org.eclipse.jetty:*</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>org.eclipse.jetty</pattern>
-                  <shadedPattern>com.treasuredata.client.jetty922</shadedPattern>
-		</relocation>
-              </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shade</shadedClassifierName>
             </configuration>
@@ -303,7 +292,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-      <version>${jetty.version}</version>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-urlconnection</artifactId>
+      <version>3.9.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,14 @@
     </dependency>
 
     <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>3.9.0</version>
+      <scope>test</scope>
+    </dependency>
+
+
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>4.0</version>
@@ -221,13 +229,6 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${jetty.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
-      <version>3.2.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -30,13 +30,13 @@ import static com.treasuredata.client.TDClientConfig.Type.API_ENDPOINT;
 import static com.treasuredata.client.TDClientConfig.Type.API_PORT;
 import static com.treasuredata.client.TDClientConfig.Type.CONNECTION_POOL_SIZE;
 import static com.treasuredata.client.TDClientConfig.Type.CONNECT_TIMEOUT_MILLIS;
-import static com.treasuredata.client.TDClientConfig.Type.READ_TIMEOUT_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.PASSOWRD;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_HOST;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_PASSWORD;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_PORT;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_USER;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_USESSL;
+import static com.treasuredata.client.TDClientConfig.Type.READ_TIMEOUT_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_INITIAL_INTERVAL_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_LIMIT;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_MAX_INTERVAL_MILLIS;
@@ -65,9 +65,6 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
     protected int readTimeoutMillis = 20000;
     protected int connectionPoolSize = 64;
     protected Multimap<String, String> headers = ImmutableMultimap.of();
-    protected Optional<Integer> requestBufferSize = Optional.absent();
-    protected Optional<Integer> responseBufferSize = Optional.absent();
-    protected Optional<Integer> maxContentLength = Optional.absent();
 
     private static Optional<String> getConfigProperty(Properties p, TDClientConfig.Type key)
     {
@@ -332,6 +329,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
 
     /**
      * Build a config object.
+     *
      * @return
      */
     public TDClientConfig buildConfig()

--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -30,7 +30,7 @@ import static com.treasuredata.client.TDClientConfig.Type.API_ENDPOINT;
 import static com.treasuredata.client.TDClientConfig.Type.API_PORT;
 import static com.treasuredata.client.TDClientConfig.Type.CONNECTION_POOL_SIZE;
 import static com.treasuredata.client.TDClientConfig.Type.CONNECT_TIMEOUT_MILLIS;
-import static com.treasuredata.client.TDClientConfig.Type.IDLE_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.READ_TIMEOUT_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.PASSOWRD;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_HOST;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_PASSWORD;
@@ -63,7 +63,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
     protected int retryMaxIntervalMillis = 60000;
     protected double retryMultiplier = 2.0;
     protected int connectTimeoutMillis = 15000;
-    protected int idleTimeoutMillis = 60000;
+    protected int readTimeoutMillis = 60000;
     protected int requestTimeoutMillis = 0;
     protected int connectionPoolSize = 64;
     protected Multimap<String, String> headers = ImmutableMultimap.of();
@@ -236,7 +236,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         this.retryMaxIntervalMillis = getConfigPropertyInt(p, RETRY_MAX_INTERVAL_MILLIS).or(retryMaxIntervalMillis);
         this.retryMultiplier = getConfigPropertyDouble(p, RETRY_MULTIPLIER).or(retryMultiplier);
         this.connectTimeoutMillis = getConfigPropertyInt(p, CONNECT_TIMEOUT_MILLIS).or(connectTimeoutMillis);
-        this.idleTimeoutMillis = getConfigPropertyInt(p, IDLE_TIMEOUT_MILLIS).or(idleTimeoutMillis);
+        this.readTimeoutMillis = getConfigPropertyInt(p, READ_TIMEOUT_MILLIS).or(readTimeoutMillis);
         this.requestTimeoutMillis = getConfigPropertyInt(p, REQUEST_TIMEOUT_MILLIS).or(requestTimeoutMillis);
         this.connectionPoolSize = getConfigPropertyInt(p, CONNECTION_POOL_SIZE).or(connectionPoolSize);
 
@@ -315,9 +315,9 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         return self();
     }
 
-    public BuilderImpl setIdleTimeoutMillis(int idleTimeoutMillis)
+    public BuilderImpl setReadTimeoutMillis(int readTimeoutMillis)
     {
-        this.idleTimeoutMillis = idleTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
         return self();
     }
 
@@ -376,7 +376,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
                 retryMaxIntervalMillis,
                 retryMultiplier,
                 connectTimeoutMillis,
-                idleTimeoutMillis,
+            readTimeoutMillis,
                 requestTimeoutMillis,
                 connectionPoolSize,
                 headers,

--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -62,7 +62,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
     protected int retryMaxIntervalMillis = 60000;
     protected double retryMultiplier = 2.0;
     protected int connectTimeoutMillis = 15000;
-    protected int readTimeoutMillis = 60000;
+    protected int readTimeoutMillis = 20000;
     protected int connectionPoolSize = 64;
     protected Multimap<String, String> headers = ImmutableMultimap.of();
     protected Optional<Integer> requestBufferSize = Optional.absent();
@@ -330,24 +330,6 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         return self();
     }
 
-    public BuilderImpl setRequestBufferSize(int requestBufferSize)
-    {
-        this.requestBufferSize = Optional.of(requestBufferSize);
-        return self();
-    }
-
-    public BuilderImpl setResponseBufferSize(int responseBufferSize)
-    {
-        this.responseBufferSize = Optional.of(responseBufferSize);
-        return self();
-    }
-
-    public BuilderImpl setMaxContentLength(int maxContentLength)
-    {
-        this.maxContentLength = Optional.of(maxContentLength);
-        return self();
-    }
-
     /**
      * Build a config object.
      * @return
@@ -369,10 +351,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
                 connectTimeoutMillis,
                 readTimeoutMillis,
                 connectionPoolSize,
-                headers,
-                requestBufferSize,
-                responseBufferSize,
-                maxContentLength);
+                headers);
     }
 
     protected abstract BuilderImpl self();

--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -37,7 +37,6 @@ import static com.treasuredata.client.TDClientConfig.Type.PROXY_PASSWORD;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_PORT;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_USER;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_USESSL;
-import static com.treasuredata.client.TDClientConfig.Type.REQUEST_TIMEOUT_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_INITIAL_INTERVAL_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_LIMIT;
 import static com.treasuredata.client.TDClientConfig.Type.RETRY_MAX_INTERVAL_MILLIS;
@@ -64,7 +63,6 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
     protected double retryMultiplier = 2.0;
     protected int connectTimeoutMillis = 15000;
     protected int readTimeoutMillis = 60000;
-    protected int requestTimeoutMillis = 0;
     protected int connectionPoolSize = 64;
     protected Multimap<String, String> headers = ImmutableMultimap.of();
     protected Optional<Integer> requestBufferSize = Optional.absent();
@@ -237,7 +235,6 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         this.retryMultiplier = getConfigPropertyDouble(p, RETRY_MULTIPLIER).or(retryMultiplier);
         this.connectTimeoutMillis = getConfigPropertyInt(p, CONNECT_TIMEOUT_MILLIS).or(connectTimeoutMillis);
         this.readTimeoutMillis = getConfigPropertyInt(p, READ_TIMEOUT_MILLIS).or(readTimeoutMillis);
-        this.requestTimeoutMillis = getConfigPropertyInt(p, REQUEST_TIMEOUT_MILLIS).or(requestTimeoutMillis);
         this.connectionPoolSize = getConfigPropertyInt(p, CONNECTION_POOL_SIZE).or(connectionPoolSize);
 
         return self();
@@ -321,12 +318,6 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         return self();
     }
 
-    public BuilderImpl setRequestTimeoutMillis(int requestTimeoutMillis)
-    {
-        this.requestTimeoutMillis = requestTimeoutMillis;
-        return self();
-    }
-
     public BuilderImpl setConnectionPoolSize(int connectionPoolSize)
     {
         this.connectionPoolSize = connectionPoolSize;
@@ -376,8 +367,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
                 retryMaxIntervalMillis,
                 retryMultiplier,
                 connectTimeoutMillis,
-            readTimeoutMillis,
-                requestTimeoutMillis,
+                readTimeoutMillis,
                 connectionPoolSize,
                 headers,
                 requestBufferSize,

--- a/src/main/java/com/treasuredata/client/ExponentialBackOff.java
+++ b/src/main/java/com/treasuredata/client/ExponentialBackOff.java
@@ -54,17 +54,16 @@ public class ExponentialBackOff
         return executionCount;
     }
 
+    public int incrementExecutionCount()
+    {
+        return executionCount++;
+    }
+
     public int nextWaitTimeMillis()
     {
-        if (executionCount == 0) {
-            executionCount++;
-            return 0;
-        }
-        else {
-            int currentWaitTimeMillis = nextIntervalMillis;
-            nextIntervalMillis = Math.min((int) (nextIntervalMillis * multiplier), maxIntervalMillis);
-            executionCount++;
-            return currentWaitTimeMillis;
-        }
+        int currentWaitTimeMillis = nextIntervalMillis;
+        nextIntervalMillis = Math.min((int) (nextIntervalMillis * multiplier), maxIntervalMillis);
+        executionCount++;
+        return currentWaitTimeMillis;
     }
 }

--- a/src/main/java/com/treasuredata/client/ExponentialBackOff.java
+++ b/src/main/java/com/treasuredata/client/ExponentialBackOff.java
@@ -56,9 +56,15 @@ public class ExponentialBackOff
 
     public int nextWaitTimeMillis()
     {
-        int currentWaitTimeMillis = nextIntervalMillis;
-        nextIntervalMillis = Math.min((int) (nextIntervalMillis * multiplier), maxIntervalMillis);
-        executionCount++;
-        return currentWaitTimeMillis;
+        if (executionCount == 0) {
+            executionCount++;
+            return 0; // No wait for the first time
+        }
+        else {
+            int currentWaitTimeMillis = nextIntervalMillis;
+            nextIntervalMillis = Math.min((int) (nextIntervalMillis * multiplier), maxIntervalMillis);
+            executionCount++;
+            return currentWaitTimeMillis;
+        }
     }
 }

--- a/src/main/java/com/treasuredata/client/ExponentialBackOff.java
+++ b/src/main/java/com/treasuredata/client/ExponentialBackOff.java
@@ -58,7 +58,7 @@ public class ExponentialBackOff
     {
         if (executionCount == 0) {
             executionCount++;
-            return 0; // No wait for the first time
+            return 0;
         }
         else {
             int currentWaitTimeMillis = nextIntervalMillis;

--- a/src/main/java/com/treasuredata/client/HttpStatus.java
+++ b/src/main/java/com/treasuredata/client/HttpStatus.java
@@ -1,0 +1,1113 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+package com.treasuredata.client;
+
+/**
+ * <p>
+ * HttpStatusCode enum class, for status codes based on various HTTP RFCs. (see
+ * table below)
+ * </p>
+ * <p>
+ * <table border="1" cellpadding="5">
+ * <tr>
+ * <th>Enum</th>
+ * <th>Code</th>
+ * <th>Message</th>
+ * <th>
+ * <a href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a></th>
+ * <th>
+ * <a href="http://tools.ietf.org/html/rfc2616">RFC 2616 - HTTP/1.1</a></th>
+ * <th>
+ * <a href="http://tools.ietf.org/html/rfc2518">RFC 2518 - WEBDAV</a></th>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td><strong><code>Informational - 1xx</code></strong></td>
+ * <td colspan="5">{@link #isInformational(int)}</td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td>{@link #CONTINUE_100}</td>
+ * <td>100</td>
+ * <td>Continue</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.1.1">Sec. 10.1.1</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #SWITCHING_PROTOCOLS_101}</td>
+ * <td>101</td>
+ * <td>Switching Protocols</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.1.2">Sec. 10.1.2</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #PROCESSING_102}</td>
+ * <td>102</td>
+ * <td>Processing</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2518#section-10.1">Sec. 10.1</a></td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td><strong><code>Success - 2xx</code></strong></td>
+ * <td colspan="5">{@link #isSuccess(int)}</td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td>{@link #OK_200}</td>
+ * <td>200</td>
+ * <td>OK</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.2">Sec. 9.2</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.2.1">Sec. 10.2.1</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #CREATED_201}</td>
+ * <td>201</td>
+ * <td>Created</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.2">Sec. 9.2</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.2.2">Sec. 10.2.2</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #ACCEPTED_202}</td>
+ * <td>202</td>
+ * <td>Accepted</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.2">Sec. 9.2</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.2.3">Sec. 10.2.3</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #NON_AUTHORITATIVE_INFORMATION_203}</td>
+ * <td>203</td>
+ * <td>Non Authoritative Information</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.2.4">Sec. 10.2.4</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #NO_CONTENT_204}</td>
+ * <td>204</td>
+ * <td>No Content</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.2">Sec. 9.2</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.2.5">Sec. 10.2.5</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #RESET_CONTENT_205}</td>
+ * <td>205</td>
+ * <td>Reset Content</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.2.6">Sec. 10.2.6</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #PARTIAL_CONTENT_206}</td>
+ * <td>206</td>
+ * <td>Partial Content</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.2.7">Sec. 10.2.7</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #MULTI_STATUS_207}</td>
+ * <td>207</td>
+ * <td>Multi-Status</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2518#section-10.2">Sec. 10.2</a></td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td><strike>207</strike></td>
+ * <td><strike>Partial Update OK</strike></td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href=
+ * "http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-rev-01.txt"
+ * >draft/01</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td><strong><code>Redirection - 3xx</code></strong></td>
+ * <td colspan="5">{@link #isRedirection(int)}</td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td>{@link #MULTIPLE_CHOICES_300}</td>
+ * <td>300</td>
+ * <td>Multiple Choices</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.3">Sec. 9.3</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.1">Sec. 10.3.1</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #MOVED_PERMANENTLY_301}</td>
+ * <td>301</td>
+ * <td>Moved Permanently</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.3">Sec. 9.3</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.2">Sec. 10.3.2</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #MOVED_TEMPORARILY_302}</td>
+ * <td>302</td>
+ * <td>Moved Temporarily</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.3">Sec. 9.3</a></td>
+ * <td>(now "<code>302 Found</code>")</td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #FOUND_302}</td>
+ * <td>302</td>
+ * <td>Found</td>
+ * <td>(was "<code>302 Moved Temporarily</code>")</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.3">Sec. 10.3.3</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #SEE_OTHER_303}</td>
+ * <td>303</td>
+ * <td>See Other</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.4">Sec. 10.3.4</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #NOT_MODIFIED_304}</td>
+ * <td>304</td>
+ * <td>Not Modified</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.3">Sec. 9.3</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.5">Sec. 10.3.5</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #USE_PROXY_305}</td>
+ * <td>305</td>
+ * <td>Use Proxy</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.6">Sec. 10.3.6</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td>306</td>
+ * <td><em>(Unused)</em></td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.7">Sec. 10.3.7</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #TEMPORARY_REDIRECT_307}</td>
+ * <td>307</td>
+ * <td>Temporary Redirect</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.3.8">Sec. 10.3.8</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td><strong><code>Client Error - 4xx</code></strong></td>
+ * <td colspan="5">{@link #isClientError(int)}</td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td>{@link #BAD_REQUEST_400}</td>
+ * <td>400</td>
+ * <td>Bad Request</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.4">Sec. 9.4</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.1">Sec. 10.4.1</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #UNAUTHORIZED_401}</td>
+ * <td>401</td>
+ * <td>Unauthorized</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.4">Sec. 9.4</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.2">Sec. 10.4.2</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #PAYMENT_REQUIRED_402}</td>
+ * <td>402</td>
+ * <td>Payment Required</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.4">Sec. 9.4</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.3">Sec. 10.4.3</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #FORBIDDEN_403}</td>
+ * <td>403</td>
+ * <td>Forbidden</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.4">Sec. 9.4</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.4">Sec. 10.4.4</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #NOT_FOUND_404}</td>
+ * <td>404</td>
+ * <td>Not Found</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.4">Sec. 9.4</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.5">Sec. 10.4.5</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #METHOD_NOT_ALLOWED_405}</td>
+ * <td>405</td>
+ * <td>Method Not Allowed</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.6">Sec. 10.4.6</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #NOT_ACCEPTABLE_406}</td>
+ * <td>406</td>
+ * <td>Not Acceptable</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.7">Sec. 10.4.7</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #PROXY_AUTHENTICATION_REQUIRED_407}</td>
+ * <td>407</td>
+ * <td>Proxy Authentication Required</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.8">Sec. 10.4.8</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #REQUEST_TIMEOUT_408}</td>
+ * <td>408</td>
+ * <td>Request Timeout</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.9">Sec. 10.4.9</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #CONFLICT_409}</td>
+ * <td>409</td>
+ * <td>Conflict</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.10">Sec. 10.4.10</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #GONE_410}</td>
+ * <td>410</td>
+ * <td>Gone</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.11">Sec. 10.4.11</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #LENGTH_REQUIRED_411}</td>
+ * <td>411</td>
+ * <td>Length Required</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.12">Sec. 10.4.12</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #PRECONDITION_FAILED_412}</td>
+ * <td>412</td>
+ * <td>Precondition Failed</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.13">Sec. 10.4.13</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #REQUEST_ENTITY_TOO_LARGE_413}</td>
+ * <td>413</td>
+ * <td>Request Entity Too Large</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.14">Sec. 10.4.14</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #REQUEST_URI_TOO_LONG_414}</td>
+ * <td>414</td>
+ * <td>Request-URI Too Long</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.15">Sec. 10.4.15</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #UNSUPPORTED_MEDIA_TYPE_415}</td>
+ * <td>415</td>
+ * <td>Unsupported Media Type</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.16">Sec. 10.4.16</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #REQUESTED_RANGE_NOT_SATISFIABLE_416}</td>
+ * <td>416</td>
+ * <td>Requested Range Not Satisfiable</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.17">Sec. 10.4.17</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #EXPECTATION_FAILED_417}</td>
+ * <td>417</td>
+ * <td>Expectation Failed</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.4.18">Sec. 10.4.18</a>
+ * </td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td><strike>418</strike></td>
+ * <td><strike>Reauthentication Required</strike></td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href=
+ * "http://tools.ietf.org/html/draft-ietf-http-v11-spec-rev-01#section-10.4.19"
+ * >draft/01</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td><strike>418</strike></td>
+ * <td><strike>Unprocessable Entity</strike></td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href=
+ * "http://tools.ietf.org/html/draft-ietf-webdav-protocol-05#section-10.3"
+ * >draft/05</a></td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td><strike>419</strike></td>
+ * <td><strike>Proxy Reauthentication Required</stike></td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href=
+ * "http://tools.ietf.org/html/draft-ietf-http-v11-spec-rev-01#section-10.4.20"
+ * >draft/01</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td><strike>419</strike></td>
+ * <td><strike>Insufficient Space on Resource</stike></td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href=
+ * "http://tools.ietf.org/html/draft-ietf-webdav-protocol-05#section-10.4"
+ * >draft/05</a></td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td><strike>420</strike></td>
+ * <td><strike>Method Failure</strike></td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href=
+ * "http://tools.ietf.org/html/draft-ietf-webdav-protocol-05#section-10.5"
+ * >draft/05</a></td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td>421</td>
+ * <td><em>(Unused)</em></td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #UNPROCESSABLE_ENTITY_422}</td>
+ * <td>422</td>
+ * <td>Unprocessable Entity</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2518#section-10.3">Sec. 10.3</a></td>
+ * </tr>
+ * <tr>
+ * <td>{@link #LOCKED_423}</td>
+ * <td>423</td>
+ * <td>Locked</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2518#section-10.4">Sec. 10.4</a></td>
+ * </tr>
+ * <tr>
+ * <td>{@link #FAILED_DEPENDENCY_424}</td>
+ * <td>424</td>
+ * <td>Failed Dependency</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2518#section-10.5">Sec. 10.5</a></td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td><strong><code>Server Error - 5xx</code></strong></td>
+ * <td colspan="5">{@link #isServerError(int)}</td>
+ * </tr>
+ * <p>
+ * <tr>
+ * <td>{@link #INTERNAL_SERVER_ERROR_500}</td>
+ * <td>500</td>
+ * <td>Internal Server Error</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.5">Sec. 9.5</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.5.1">Sec. 10.5.1</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #NOT_IMPLEMENTED_501}</td>
+ * <td>501</td>
+ * <td>Not Implemented</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.5">Sec. 9.5</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.5.2">Sec. 10.5.2</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #BAD_GATEWAY_502}</td>
+ * <td>502</td>
+ * <td>Bad Gateway</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.5">Sec. 9.5</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.5.3">Sec. 10.5.3</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #SERVICE_UNAVAILABLE_503}</td>
+ * <td>503</td>
+ * <td>Service Unavailable</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc1945#section-9.5">Sec. 9.5</a></td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.5.4">Sec. 10.5.4</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #GATEWAY_TIMEOUT_504}</td>
+ * <td>504</td>
+ * <td>Gateway Timeout</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.5.5">Sec. 10.5.5</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #HTTP_VERSION_NOT_SUPPORTED_505}</td>
+ * <td>505</td>
+ * <td>HTTP Version Not Supported</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2616#section-10.5.6">Sec. 10.5.6</a></td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>&nbsp;</td>
+ * <td>506</td>
+ * <td><em>(Unused)</em></td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #INSUFFICIENT_STORAGE_507}</td>
+ * <td>507</td>
+ * <td>Insufficient Storage</td>
+ * <td>&nbsp;</td>
+ * <td>&nbsp;</td>
+ * <td>
+ * <a href="http://tools.ietf.org/html/rfc2518#section-10.6">Sec. 10.6</a></td>
+ * </tr>
+ * <p>
+ * </table>
+ *
+ * @version $Id$
+ */
+public class HttpStatus
+{
+    public final static int CONTINUE_100 = 100;
+    public final static int SWITCHING_PROTOCOLS_101 = 101;
+    public final static int PROCESSING_102 = 102;
+
+    public final static int OK_200 = 200;
+    public final static int CREATED_201 = 201;
+    public final static int ACCEPTED_202 = 202;
+    public final static int NON_AUTHORITATIVE_INFORMATION_203 = 203;
+    public final static int NO_CONTENT_204 = 204;
+    public final static int RESET_CONTENT_205 = 205;
+    public final static int PARTIAL_CONTENT_206 = 206;
+    public final static int MULTI_STATUS_207 = 207;
+
+    public final static int MULTIPLE_CHOICES_300 = 300;
+    public final static int MOVED_PERMANENTLY_301 = 301;
+    public final static int MOVED_TEMPORARILY_302 = 302;
+    public final static int FOUND_302 = 302;
+    public final static int SEE_OTHER_303 = 303;
+    public final static int NOT_MODIFIED_304 = 304;
+    public final static int USE_PROXY_305 = 305;
+    public final static int TEMPORARY_REDIRECT_307 = 307;
+
+    public final static int BAD_REQUEST_400 = 400;
+    public final static int UNAUTHORIZED_401 = 401;
+    public final static int PAYMENT_REQUIRED_402 = 402;
+    public final static int FORBIDDEN_403 = 403;
+    public final static int NOT_FOUND_404 = 404;
+    public final static int METHOD_NOT_ALLOWED_405 = 405;
+    public final static int NOT_ACCEPTABLE_406 = 406;
+    public final static int PROXY_AUTHENTICATION_REQUIRED_407 = 407;
+    public final static int REQUEST_TIMEOUT_408 = 408;
+    public final static int CONFLICT_409 = 409;
+    public final static int GONE_410 = 410;
+    public final static int LENGTH_REQUIRED_411 = 411;
+    public final static int PRECONDITION_FAILED_412 = 412;
+    public final static int REQUEST_ENTITY_TOO_LARGE_413 = 413;
+    public final static int REQUEST_URI_TOO_LONG_414 = 414;
+    public final static int UNSUPPORTED_MEDIA_TYPE_415 = 415;
+    public final static int REQUESTED_RANGE_NOT_SATISFIABLE_416 = 416;
+    public final static int EXPECTATION_FAILED_417 = 417;
+    public final static int UNPROCESSABLE_ENTITY_422 = 422;
+    public final static int LOCKED_423 = 423;
+    public final static int FAILED_DEPENDENCY_424 = 424;
+
+    public final static int INTERNAL_SERVER_ERROR_500 = 500;
+    public final static int NOT_IMPLEMENTED_501 = 501;
+    public final static int BAD_GATEWAY_502 = 502;
+    public final static int SERVICE_UNAVAILABLE_503 = 503;
+    public final static int GATEWAY_TIMEOUT_504 = 504;
+    public final static int HTTP_VERSION_NOT_SUPPORTED_505 = 505;
+    public final static int INSUFFICIENT_STORAGE_507 = 507;
+
+    public static final int MAX_CODE = 507;
+
+    private static final Code[] codeMap = new Code[MAX_CODE + 1];
+
+    static {
+        for (Code code : Code.values()) {
+            codeMap[code._code] = code;
+        }
+    }
+
+    public enum Code
+    {
+        /*
+         * --------------------------------------------------------------------
+         * Informational messages in 1xx series. As defined by ... RFC 1945 -
+         * HTTP/1.0 RFC 2616 - HTTP/1.1 RFC 2518 - WebDAV
+         */
+
+        /**
+         * <code>100 Continue</code>
+         */
+        CONTINUE(CONTINUE_100, "Continue"),
+        /**
+         * <code>101 Switching Protocols</code>
+         */
+        SWITCHING_PROTOCOLS(SWITCHING_PROTOCOLS_101, "Switching Protocols"),
+        /**
+         * <code>102 Processing</code>
+         */
+        PROCESSING(PROCESSING_102, "Processing"),
+
+        /*
+         * --------------------------------------------------------------------
+         * Success messages in 2xx series. As defined by ... RFC 1945 - HTTP/1.0
+         * RFC 2616 - HTTP/1.1 RFC 2518 - WebDAV
+         */
+
+        /**
+         * <code>200 OK</code>
+         */
+        OK(OK_200, "OK"),
+        /**
+         * <code>201 Created</code>
+         */
+        CREATED(CREATED_201, "Created"),
+        /**
+         * <code>202 Accepted</code>
+         */
+        ACCEPTED(ACCEPTED_202, "Accepted"),
+        /**
+         * <code>203 Non Authoritative Information</code>
+         */
+        NON_AUTHORITATIVE_INFORMATION(NON_AUTHORITATIVE_INFORMATION_203, "Non Authoritative Information"),
+        /**
+         * <code>204 No Content</code>
+         */
+        NO_CONTENT(NO_CONTENT_204, "No Content"),
+        /**
+         * <code>205 Reset Content</code>
+         */
+        RESET_CONTENT(RESET_CONTENT_205, "Reset Content"),
+        /**
+         * <code>206 Partial Content</code>
+         */
+        PARTIAL_CONTENT(PARTIAL_CONTENT_206, "Partial Content"),
+        /**
+         * <code>207 Multi-Status</code>
+         */
+        MULTI_STATUS(MULTI_STATUS_207, "Multi-Status"),
+
+        /*
+         * --------------------------------------------------------------------
+         * Redirection messages in 3xx series. As defined by ... RFC 1945 -
+         * HTTP/1.0 RFC 2616 - HTTP/1.1
+         */
+
+        /**
+         * <code>300 Mutliple Choices</code>
+         */
+        MULTIPLE_CHOICES(MULTIPLE_CHOICES_300, "Multiple Choices"),
+        /**
+         * <code>301 Moved Permanently</code>
+         */
+        MOVED_PERMANENTLY(MOVED_PERMANENTLY_301, "Moved Permanently"),
+        /**
+         * <code>302 Moved Temporarily</code>
+         */
+        MOVED_TEMPORARILY(MOVED_TEMPORARILY_302, "Moved Temporarily"),
+        /**
+         * <code>302 Found</code>
+         */
+        FOUND(FOUND_302, "Found"),
+        /**
+         * <code>303 See Other</code>
+         */
+        SEE_OTHER(SEE_OTHER_303, "See Other"),
+        /**
+         * <code>304 Not Modified</code>
+         */
+        NOT_MODIFIED(NOT_MODIFIED_304, "Not Modified"),
+        /**
+         * <code>305 Use Proxy</code>
+         */
+        USE_PROXY(USE_PROXY_305, "Use Proxy"),
+        /**
+         * <code>307 Temporary Redirect</code>
+         */
+        TEMPORARY_REDIRECT(TEMPORARY_REDIRECT_307, "Temporary Redirect"),
+
+        /*
+         * --------------------------------------------------------------------
+         * Client Error messages in 4xx series. As defined by ... RFC 1945 -
+         * HTTP/1.0 RFC 2616 - HTTP/1.1 RFC 2518 - WebDAV
+         */
+
+        /**
+         * <code>400 Bad Request</code>
+         */
+        BAD_REQUEST(BAD_REQUEST_400, "Bad Request"),
+        /**
+         * <code>401 Unauthorized</code>
+         */
+        UNAUTHORIZED(UNAUTHORIZED_401, "Unauthorized"),
+        /**
+         * <code>402 Payment Required</code>
+         */
+        PAYMENT_REQUIRED(PAYMENT_REQUIRED_402, "Payment Required"),
+        /**
+         * <code>403 Forbidden</code>
+         */
+        FORBIDDEN(FORBIDDEN_403, "Forbidden"),
+        /**
+         * <code>404 Not Found</code>
+         */
+        NOT_FOUND(NOT_FOUND_404, "Not Found"),
+        /**
+         * <code>405 Method Not Allowed</code>
+         */
+        METHOD_NOT_ALLOWED(METHOD_NOT_ALLOWED_405, "Method Not Allowed"),
+        /**
+         * <code>406 Not Acceptable</code>
+         */
+        NOT_ACCEPTABLE(NOT_ACCEPTABLE_406, "Not Acceptable"),
+        /**
+         * <code>407 Proxy Authentication Required</code>
+         */
+        PROXY_AUTHENTICATION_REQUIRED(PROXY_AUTHENTICATION_REQUIRED_407, "Proxy Authentication Required"),
+        /**
+         * <code>408 Request Timeout</code>
+         */
+        REQUEST_TIMEOUT(REQUEST_TIMEOUT_408, "Request Timeout"),
+        /**
+         * <code>409 Conflict</code>
+         */
+        CONFLICT(CONFLICT_409, "Conflict"),
+        /**
+         * <code>410 Gone</code>
+         */
+        GONE(GONE_410, "Gone"),
+        /**
+         * <code>411 Length Required</code>
+         */
+        LENGTH_REQUIRED(LENGTH_REQUIRED_411, "Length Required"),
+        /**
+         * <code>412 Precondition Failed</code>
+         */
+        PRECONDITION_FAILED(PRECONDITION_FAILED_412, "Precondition Failed"),
+        /**
+         * <code>413 Request Entity Too Large</code>
+         */
+        REQUEST_ENTITY_TOO_LARGE(REQUEST_ENTITY_TOO_LARGE_413, "Request Entity Too Large"),
+        /**
+         * <code>414 Request-URI Too Long</code>
+         */
+        REQUEST_URI_TOO_LONG(REQUEST_URI_TOO_LONG_414, "Request-URI Too Long"),
+        /**
+         * <code>415 Unsupported Media Type</code>
+         */
+        UNSUPPORTED_MEDIA_TYPE(UNSUPPORTED_MEDIA_TYPE_415, "Unsupported Media Type"),
+        /**
+         * <code>416 Requested Range Not Satisfiable</code>
+         */
+        REQUESTED_RANGE_NOT_SATISFIABLE(REQUESTED_RANGE_NOT_SATISFIABLE_416, "Requested Range Not Satisfiable"),
+        /**
+         * <code>417 Expectation Failed</code>
+         */
+        EXPECTATION_FAILED(EXPECTATION_FAILED_417, "Expectation Failed"),
+        /**
+         * <code>422 Unprocessable Entity</code>
+         */
+        UNPROCESSABLE_ENTITY(UNPROCESSABLE_ENTITY_422, "Unprocessable Entity"),
+        /**
+         * <code>423 Locked</code>
+         */
+        LOCKED(LOCKED_423, "Locked"),
+        /**
+         * <code>424 Failed Dependency</code>
+         */
+        FAILED_DEPENDENCY(FAILED_DEPENDENCY_424, "Failed Dependency"),
+
+        /*
+         * --------------------------------------------------------------------
+         * Server Error messages in 5xx series. As defined by ... RFC 1945 -
+         * HTTP/1.0 RFC 2616 - HTTP/1.1 RFC 2518 - WebDAV
+         */
+
+        /**
+         * <code>500 Server Error</code>
+         */
+        INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR_500, "Server Error"),
+        /**
+         * <code>501 Not Implemented</code>
+         */
+        NOT_IMPLEMENTED(NOT_IMPLEMENTED_501, "Not Implemented"),
+        /**
+         * <code>502 Bad Gateway</code>
+         */
+        BAD_GATEWAY(BAD_GATEWAY_502, "Bad Gateway"),
+        /**
+         * <code>503 Service Unavailable</code>
+         */
+        SERVICE_UNAVAILABLE(SERVICE_UNAVAILABLE_503, "Service Unavailable"),
+        /**
+         * <code>504 Gateway Timeout</code>
+         */
+        GATEWAY_TIMEOUT(GATEWAY_TIMEOUT_504, "Gateway Timeout"),
+        /**
+         * <code>505 HTTP Version Not Supported</code>
+         */
+        HTTP_VERSION_NOT_SUPPORTED(HTTP_VERSION_NOT_SUPPORTED_505, "HTTP Version Not Supported"),
+        /**
+         * <code>507 Insufficient Storage</code>
+         */
+        INSUFFICIENT_STORAGE(INSUFFICIENT_STORAGE_507, "Insufficient Storage");
+
+        private final int _code;
+        private final String _message;
+
+        private Code(int code, String message)
+        {
+            this._code = code;
+            _message = message;
+        }
+
+        public int getCode()
+        {
+            return _code;
+        }
+
+        public String getMessage()
+        {
+            return _message;
+        }
+
+        public boolean equals(int code)
+        {
+            return (this._code == code);
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("[%03d %s]", this._code, this.getMessage());
+        }
+
+        /**
+         * Simple test against an code to determine if it falls into the
+         * <code>Informational</code> message category as defined in the <a
+         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
+         * and <a href="http://tools.ietf.org/html/rfc2616">RFC 2616 -
+         * HTTP/1.1</a>.
+         *
+         * @return true if within range of codes that belongs to
+         * <code>Informational</code> messages.
+         */
+        public boolean isInformational()
+        {
+            return HttpStatus.isInformational(this._code);
+        }
+
+        /**
+         * Simple test against an code to determine if it falls into the
+         * <code>Success</code> message category as defined in the <a
+         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
+         * and <a href="http://tools.ietf.org/html/rfc2616">RFC 2616 -
+         * HTTP/1.1</a>.
+         *
+         * @return true if within range of codes that belongs to
+         * <code>Success</code> messages.
+         */
+        public boolean isSuccess()
+        {
+            return HttpStatus.isSuccess(this._code);
+        }
+
+        /**
+         * Simple test against an code to determine if it falls into the
+         * <code>Redirection</code> message category as defined in the <a
+         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
+         * and <a href="http://tools.ietf.org/html/rfc2616">RFC 2616 -
+         * HTTP/1.1</a>.
+         *
+         * @return true if within range of codes that belongs to
+         * <code>Redirection</code> messages.
+         */
+        public boolean isRedirection()
+        {
+            return HttpStatus.isRedirection(this._code);
+        }
+
+        /**
+         * Simple test against an code to determine if it falls into the
+         * <code>Client Error</code> message category as defined in the <a
+         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
+         * and <a href="http://tools.ietf.org/html/rfc2616">RFC 2616 -
+         * HTTP/1.1</a>.
+         *
+         * @return true if within range of codes that belongs to
+         * <code>Client Error</code> messages.
+         */
+        public boolean isClientError()
+        {
+            return HttpStatus.isClientError(this._code);
+        }
+
+        /**
+         * Simple test against an code to determine if it falls into the
+         * <code>Server Error</code> message category as defined in the <a
+         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
+         * and <a href="http://tools.ietf.org/html/rfc2616">RFC 2616 -
+         * HTTP/1.1</a>.
+         *
+         * @return true if within range of codes that belongs to
+         * <code>Server Error</code> messages.
+         */
+        public boolean isServerError()
+        {
+            return HttpStatus.isServerError(this._code);
+        }
+    }
+
+    /**
+     * Get the HttpStatusCode for a specific code
+     *
+     * @param code the code to lookup.
+     * @return the {@link HttpStatus} if found, or null if not found.
+     */
+    public static Code getCode(int code)
+    {
+        if (code <= MAX_CODE) {
+            return codeMap[code];
+        }
+        return null;
+    }
+
+    /**
+     * Get the status message for a specific code.
+     *
+     * @param code the code to look up
+     * @return the specific message, or the code number itself if code
+     * does not match known list.
+     */
+    public static String getMessage(int code)
+    {
+        Code codeEnum = getCode(code);
+        if (codeEnum != null) {
+            return codeEnum.getMessage();
+        }
+        else {
+            return Integer.toString(code);
+        }
+    }
+
+    /**
+     * Simple test against an code to determine if it falls into the
+     * <code>Informational</code> message category as defined in the <a
+     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
+     * href="http://tools.ietf.org/html/rfc2616">RFC 2616 - HTTP/1.1</a>.
+     *
+     * @param code the code to test.
+     * @return true if within range of codes that belongs to
+     * <code>Informational</code> messages.
+     */
+    public static boolean isInformational(int code)
+    {
+        return ((100 <= code) && (code <= 199));
+    }
+
+    /**
+     * Simple test against an code to determine if it falls into the
+     * <code>Success</code> message category as defined in the <a
+     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
+     * href="http://tools.ietf.org/html/rfc2616">RFC 2616 - HTTP/1.1</a>.
+     *
+     * @param code the code to test.
+     * @return true if within range of codes that belongs to
+     * <code>Success</code> messages.
+     */
+    public static boolean isSuccess(int code)
+    {
+        return ((200 <= code) && (code <= 299));
+    }
+
+    /**
+     * Simple test against an code to determine if it falls into the
+     * <code>Redirection</code> message category as defined in the <a
+     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
+     * href="http://tools.ietf.org/html/rfc2616">RFC 2616 - HTTP/1.1</a>.
+     *
+     * @param code the code to test.
+     * @return true if within range of codes that belongs to
+     * <code>Redirection</code> messages.
+     */
+    public static boolean isRedirection(int code)
+    {
+        return ((300 <= code) && (code <= 399));
+    }
+
+    /**
+     * Simple test against an code to determine if it falls into the
+     * <code>Client Error</code> message category as defined in the <a
+     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
+     * href="http://tools.ietf.org/html/rfc2616">RFC 2616 - HTTP/1.1</a>.
+     *
+     * @param code the code to test.
+     * @return true if within range of codes that belongs to
+     * <code>Client Error</code> messages.
+     */
+    public static boolean isClientError(int code)
+    {
+        return ((400 <= code) && (code <= 499));
+    }
+
+    /**
+     * Simple test against an code to determine if it falls into the
+     * <code>Server Error</code> message category as defined in the <a
+     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
+     * href="http://tools.ietf.org/html/rfc2616">RFC 2616 - HTTP/1.1</a>.
+     *
+     * @param code the code to test.
+     * @return true if within range of codes that belongs to
+     * <code>Server Error</code> messages.
+     */
+    public static boolean isServerError(int code)
+    {
+        return ((500 <= code) && (code <= 599));
+    }
+}

--- a/src/main/java/com/treasuredata/client/TDApiRequest.java
+++ b/src/main/java/com/treasuredata/client/TDApiRequest.java
@@ -70,6 +70,11 @@ public class TDApiRequest
         this.followRedirects = checkNotNull(followRedirects, "followRedirects is null");
     }
 
+    public TDApiRequest withUri(String uri)
+    {
+        return new TDApiRequest(method, uri, ImmutableMap.copyOf(queryParams), ImmutableMultimap.copyOf(headerParams), postJson, putFile, followRedirects);
+    }
+
     public String getPath()
     {
         return path;

--- a/src/main/java/com/treasuredata/client/TDApiRequest.java
+++ b/src/main/java/com/treasuredata/client/TDApiRequest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
-import org.eclipse.jetty.http.HttpMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +43,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class TDApiRequest
 {
     private static Logger logger = LoggerFactory.getLogger(TDApiRequest.class);
-    private final HttpMethod method;
+    private final TDHttpMethod method;
     private final String path;
     private final Map<String, String> queryParams;
     private final Multimap<String, String> headerParams;
@@ -53,7 +52,7 @@ public class TDApiRequest
     private final Optional<Boolean> followRedirects;
 
     TDApiRequest(
-            HttpMethod method,
+            TDHttpMethod method,
             String path,
             Map<String, String> queryParams,
             Multimap<String, String> headerParams,
@@ -76,7 +75,7 @@ public class TDApiRequest
         return path;
     }
 
-    public HttpMethod getMethod()
+    public TDHttpMethod getMethod()
     {
         return method;
     }
@@ -110,7 +109,7 @@ public class TDApiRequest
     {
         private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
         private static final Multimap<String, String> EMPTY_HEADERS = ImmutableMultimap.of();
-        private HttpMethod method;
+        private TDHttpMethod method;
         private String path;
         private Map<String, String> queryParams;
         private ImmutableMultimap.Builder<String, String> headerParams;
@@ -118,7 +117,7 @@ public class TDApiRequest
         private Optional<File> file = Optional.absent();
         private Optional<Boolean> followRedirects = Optional.absent();
 
-        Builder(HttpMethod method, String path)
+        Builder(TDHttpMethod method, String path)
         {
             this.method = method;
             this.path = path;
@@ -126,22 +125,22 @@ public class TDApiRequest
 
         public static Builder GET(String uri)
         {
-            return new Builder(HttpMethod.GET, uri);
+            return new Builder(TDHttpMethod.GET, uri);
         }
 
         public static Builder POST(String uri)
         {
-            return new Builder(HttpMethod.POST, uri);
+            return new Builder(TDHttpMethod.POST, uri);
         }
 
         public static Builder PUT(String uri)
         {
-            return new Builder(HttpMethod.PUT, uri);
+            return new Builder(TDHttpMethod.PUT, uri);
         }
 
         public static Builder DELETE(String uri)
         {
-            return new Builder(HttpMethod.DELETE, uri);
+            return new Builder(TDHttpMethod.DELETE, uri);
         }
 
         public Builder addHeader(String key, String value)

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -405,8 +405,7 @@ public class TDClient
             return false;
         }
         catch (TDClientHttpException e) {
-            // NOT_FOUND error
-            if (e.getStatusCode() == 404) {
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND_404) {
                 return false;
             }
             else {

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -60,7 +60,6 @@ import com.treasuredata.client.model.TDUpdateTableResult;
 import com.treasuredata.client.model.TDUser;
 import com.treasuredata.client.model.TDUserList;
 import com.treasuredata.client.model.impl.TDScheduleRunResult;
-import org.eclipse.jetty.http.HttpStatus;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -406,7 +405,8 @@ public class TDClient
             return false;
         }
         catch (TDClientHttpException e) {
-            if (e.getStatusCode() == HttpStatus.NOT_FOUND_404) {
+            // NOT_FOUND error
+            if (e.getStatusCode() == 404) {
                 return false;
             }
             else {

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -60,9 +60,6 @@ public class TDClientConfig
         CONNECT_TIMEOUT_MILLIS("td.client.connect-timeout", "connection timeout before reaching the API"),
         READ_TIMEOUT_MILLIS("td.client.read-timeout", "connection read timeout from API"),
         CONNECTION_POOL_SIZE("td.client.connection-pool-size", "connection pool size"),
-        REQUEST_BUFFER_SIZE("td.client.request-buffer-size", "request buffer size"),
-        RESPONSE_BUFFER_SIZE("td.client.response-buffer-size", "response buffer size"),
-        MAX_CONTENT_LENGTH("td.client.max-content-length", "maximum response body content length"),
         PROXY_HOST("td.client.proxy.host", "Proxy host (e.g., myproxy.com)"),
         PROXY_PORT("td.client.proxy.port", "Proxy port number"),
         PROXY_USER("td.client.proxy.user", "Proxy user name"),
@@ -106,9 +103,6 @@ public class TDClientConfig
     public final int readTimeoutMillis;
     public final int connectionPoolSize;
     public final Multimap<String, String> headers;
-    public final Optional<Integer> requestBufferSize;
-    public final Optional<Integer> responseBufferSize;
-    public final Optional<Integer> maxContentLength;
 
     @JsonCreator
     TDClientConfig(
@@ -126,10 +120,7 @@ public class TDClientConfig
             int connectTimeoutMillis,
             int readTimeoutMillis,
             int connectionPoolSize,
-            Multimap<String, String> headers,
-            Optional<Integer> requestBufferSize,
-            Optional<Integer> responseBufferSize,
-            Optional<Integer> maxContentLength)
+            Multimap<String, String> headers)
     {
         this.endpoint = endpoint.or("api.treasuredata.com");
         this.port = port;
@@ -146,9 +137,6 @@ public class TDClientConfig
         this.readTimeoutMillis = readTimeoutMillis;
         this.connectionPoolSize = connectionPoolSize;
         this.headers = headers;
-        this.requestBufferSize = requestBufferSize;
-        this.responseBufferSize = responseBufferSize;
-        this.maxContentLength = maxContentLength;
     }
 
     public TDClientConfig withApiKey(String apikey)
@@ -173,10 +161,7 @@ public class TDClientConfig
                 connectTimeoutMillis,
                 readTimeoutMillis,
                 connectionPoolSize,
-                headers,
-                requestBufferSize,
-                responseBufferSize,
-                maxContentLength
+                headers
         );
     }
 
@@ -226,10 +211,6 @@ public class TDClientConfig
         saveProperty(p, Type.RETRY_MULTIPLIER, retryMultiplier);
         saveProperty(p, Type.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis);
         saveProperty(p, Type.CONNECTION_POOL_SIZE, connectionPoolSize);
-        saveProperty(p, Type.MAX_CONTENT_LENGTH, maxContentLength);
-        saveProperty(p, Type.REQUEST_BUFFER_SIZE, requestBufferSize);
-        saveProperty(p, Type.RESPONSE_BUFFER_SIZE, responseBufferSize);
-        saveProperty(p, Type.MAX_CONTENT_LENGTH, maxContentLength);
         return p;
     }
 

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -58,7 +58,7 @@ public class TDClientConfig
         RETRY_MAX_INTERVAL_MILLIS("td.client.retry.max-interval", "max retry interval"),
         RETRY_MULTIPLIER("td.client.retry.multiplier", "retry interval multiplier"),
         CONNECT_TIMEOUT_MILLIS("td.client.connect-timeout", "connection timeout before reaching the API"),
-        IDLE_TIMEOUT_MILLIS("td.client.idle-timeout", "idle connection timeout when no data is coming from API"),
+        READ_TIMEOUT_MILLIS("td.client.read-timeout", "connection read timeout from API"),
         REQUEST_TIMEOUT_MILLIS("td.client.request-timeout", "timeout during executing a request"),
         CONNECTION_POOL_SIZE("td.client.connection-pool-size", "connection pool size"),
         REQUEST_BUFFER_SIZE("td.client.request-buffer-size", "request buffer size"),
@@ -104,7 +104,7 @@ public class TDClientConfig
     public final int retryMaxIntervalMillis;
     public final double retryMultiplier;
     public final int connectTimeoutMillis;
-    public final int idleTimeoutMillis;
+    public final int readTimeoutMillis;
     public final int requestTimeoutMillis;
     public final int connectionPoolSize;
     public final Multimap<String, String> headers;
@@ -126,7 +126,7 @@ public class TDClientConfig
             int retryMaxIntervalMillis,
             double retryMultiplier,
             int connectTimeoutMillis,
-            int idleTimeoutMillis,
+            int readTimeoutMillis,
             int requestTimeoutMillis,
             int connectionPoolSize,
             Multimap<String, String> headers,
@@ -146,7 +146,7 @@ public class TDClientConfig
         this.retryMaxIntervalMillis = retryMaxIntervalMillis;
         this.retryMultiplier = retryMultiplier;
         this.connectTimeoutMillis = connectTimeoutMillis;
-        this.idleTimeoutMillis = idleTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
         this.requestTimeoutMillis = requestTimeoutMillis;
         this.connectionPoolSize = connectionPoolSize;
         this.headers = headers;
@@ -175,7 +175,7 @@ public class TDClientConfig
                 retryMaxIntervalMillis,
                 retryMultiplier,
                 connectTimeoutMillis,
-                idleTimeoutMillis,
+                readTimeoutMillis,
                 requestTimeoutMillis,
                 connectionPoolSize,
                 headers,

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -59,7 +59,6 @@ public class TDClientConfig
         RETRY_MULTIPLIER("td.client.retry.multiplier", "retry interval multiplier"),
         CONNECT_TIMEOUT_MILLIS("td.client.connect-timeout", "connection timeout before reaching the API"),
         READ_TIMEOUT_MILLIS("td.client.read-timeout", "connection read timeout from API"),
-        REQUEST_TIMEOUT_MILLIS("td.client.request-timeout", "timeout during executing a request"),
         CONNECTION_POOL_SIZE("td.client.connection-pool-size", "connection pool size"),
         REQUEST_BUFFER_SIZE("td.client.request-buffer-size", "request buffer size"),
         RESPONSE_BUFFER_SIZE("td.client.response-buffer-size", "response buffer size"),
@@ -105,7 +104,6 @@ public class TDClientConfig
     public final double retryMultiplier;
     public final int connectTimeoutMillis;
     public final int readTimeoutMillis;
-    public final int requestTimeoutMillis;
     public final int connectionPoolSize;
     public final Multimap<String, String> headers;
     public final Optional<Integer> requestBufferSize;
@@ -127,7 +125,6 @@ public class TDClientConfig
             double retryMultiplier,
             int connectTimeoutMillis,
             int readTimeoutMillis,
-            int requestTimeoutMillis,
             int connectionPoolSize,
             Multimap<String, String> headers,
             Optional<Integer> requestBufferSize,
@@ -147,7 +144,6 @@ public class TDClientConfig
         this.retryMultiplier = retryMultiplier;
         this.connectTimeoutMillis = connectTimeoutMillis;
         this.readTimeoutMillis = readTimeoutMillis;
-        this.requestTimeoutMillis = requestTimeoutMillis;
         this.connectionPoolSize = connectionPoolSize;
         this.headers = headers;
         this.requestBufferSize = requestBufferSize;
@@ -176,7 +172,6 @@ public class TDClientConfig
                 retryMultiplier,
                 connectTimeoutMillis,
                 readTimeoutMillis,
-                requestTimeoutMillis,
                 connectionPoolSize,
                 headers,
                 requestBufferSize,
@@ -230,7 +225,6 @@ public class TDClientConfig
         saveProperty(p, Type.RETRY_MAX_INTERVAL_MILLIS, retryMaxIntervalMillis);
         saveProperty(p, Type.RETRY_MULTIPLIER, retryMultiplier);
         saveProperty(p, Type.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis);
-        saveProperty(p, Type.REQUEST_TIMEOUT_MILLIS, requestTimeoutMillis);
         saveProperty(p, Type.CONNECTION_POOL_SIZE, connectionPoolSize);
         saveProperty(p, Type.MAX_CONTENT_LENGTH, maxContentLength);
         saveProperty(p, Type.REQUEST_BUFFER_SIZE, requestBufferSize);

--- a/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
@@ -19,7 +19,6 @@
 package com.treasuredata.client;
 
 import com.google.common.base.Optional;
-import org.eclipse.jetty.http.HttpStatus;
 
 /**
  * On 409 conflict error (e.g., database already exists)

--- a/src/main/java/com/treasuredata/client/TDClientHttpNotFoundException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpNotFoundException.java
@@ -18,8 +18,6 @@
  */
 package com.treasuredata.client;
 
-import org.eclipse.jetty.http.HttpStatus;
-
 /**
  * On 404 NOT_FOUND error when target query, job_id, database, etc. is not found
  */

--- a/src/main/java/com/treasuredata/client/TDClientProcessingException.java
+++ b/src/main/java/com/treasuredata/client/TDClientProcessingException.java
@@ -18,15 +18,13 @@
  */
 package com.treasuredata.client;
 
-import java.io.IOException;
-
 /**
  * Thrown when processing API request has failed
  */
 public class TDClientProcessingException
         extends TDClientException
 {
-    public TDClientProcessingException(IOException cause)
+    public TDClientProcessingException(Exception cause)
     {
         super(ErrorType.EXECUTION_FAILURE, cause);
     }

--- a/src/main/java/com/treasuredata/client/TDClientProcessingException.java
+++ b/src/main/java/com/treasuredata/client/TDClientProcessingException.java
@@ -18,7 +18,7 @@
  */
 package com.treasuredata.client;
 
-import java.util.concurrent.ExecutionException;
+import java.io.IOException;
 
 /**
  * Thrown when processing API request has failed
@@ -26,7 +26,7 @@ import java.util.concurrent.ExecutionException;
 public class TDClientProcessingException
         extends TDClientException
 {
-    public TDClientProcessingException(ExecutionException cause)
+    public TDClientProcessingException(IOException cause)
     {
         super(ErrorType.EXECUTION_FAILURE, cause);
     }

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -355,9 +355,13 @@ public class TDHttpClient
             throw context.rootCause.get();
         }
         else {
-            // This will increment execution count
-            long waitTimeMillis = calculateWaitTimeMillis(context.backoff.nextWaitTimeMillis(), context.rootCause);
-            if (waitTimeMillis > 0) {
+            if (executionCount == 0) {
+                // First attempt
+                context.backoff.incrementExecutionCount();
+            }
+            else {
+                // Requst retry
+                long waitTimeMillis = calculateWaitTimeMillis(context.backoff.nextWaitTimeMillis(), context.rootCause);
                 logger.warn(String.format("Retrying request to %s (%d/%d) in %.2f sec.", context.apiRequest.getPath(), executionCount, config.retryLimit, waitTimeMillis / 1000.0));
                 // Sleeping for a while. This may throw InterruptedException
                 Thread.sleep(waitTimeMillis);

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -281,10 +281,10 @@ public class TDHttpClient
 
         // Set other headers
         for (Map.Entry<String, String> entry : headers.entries()) {
-            request = request.header(entry.getKey(), entry.getValue());
+            request = request.addHeader(entry.getKey(), entry.getValue());
         }
         for (Map.Entry<String, String> entry : apiRequest.getHeaderParams().entries()) {
-            request = request.header(entry.getKey(), entry.getValue());
+            request = request.addHeader(entry.getKey(), entry.getValue());
         }
 
         // Set API Key after setting the other headers

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -36,7 +36,6 @@ import com.google.common.collect.Multimap;
 import com.treasuredata.client.impl.ProxyAuthenticator;
 import com.treasuredata.client.model.JsonCollectionRootName;
 import com.treasuredata.client.model.TDApiErrorMessage;
-import okhttp3.CacheControl;
 import okhttp3.ConnectionPool;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.MediaType;
@@ -44,6 +43,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okhttp3.internal.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -651,7 +651,9 @@ public class TDHttpClient
             public Result onSuccess(Response response)
                     throws Exception
             {
-                return contentStreamHandler.apply(response.body().byteStream());
+                try (ResponseBody body = response.body()) {
+                    return contentStreamHandler.apply(body.byteStream());
+                }
             }
         });
         return result;
@@ -805,7 +807,7 @@ public class TDHttpClient
         @Override
         public boolean isSuccess(Response response)
         {
-            return HttpStatus.isSuccess(response.code());
+            return response.isSuccessful();
         }
 
         @Override

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -188,7 +188,9 @@ public class TDHttpClient
 
     public void close()
     {
-        // No need to close OkHttp client
+        // Cleanup the internal thread manager and connections
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
     }
 
     @VisibleForTesting

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -284,7 +284,6 @@ public class TDHttpClient
         Request.Builder request =
                 new Request.Builder()
                         .url(requestUri)
-                        .cacheControl(CacheControl.FORCE_NETWORK) // Do not cache the result
                         .header(USER_AGENT, getClientName())
                         .header(DATE, dateHeader);
 

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -399,28 +399,28 @@ public class TDHttpClient
             return Optional.<TDClientException>of(new TDClientTimeoutException(e));
         }
         else if (e instanceof SocketException) {
-            final SocketException causeSocket = (SocketException) e.getCause();
-            if (causeSocket instanceof BindException ||
-                    causeSocket instanceof ConnectException ||
-                    causeSocket instanceof NoRouteToHostException ||
-                    causeSocket instanceof PortUnreachableException) {
+            final SocketException socketException = (SocketException) e;
+            if (socketException instanceof BindException ||
+                    socketException instanceof ConnectException ||
+                    socketException instanceof NoRouteToHostException ||
+                    socketException instanceof PortUnreachableException) {
                 // All known SocketException are retryable.
-                return Optional.<TDClientException>of(new TDClientSocketException(causeSocket));
+                return Optional.<TDClientException>of(new TDClientSocketException(socketException));
             }
             else {
                 // Other unknown SocketException are considered non-retryable.
-                throw new TDClientSocketException(causeSocket);
+                throw new TDClientSocketException(socketException);
             }
         }
         else if (e instanceof SSLException) {
-            SSLException cause = (SSLException) e.getCause();
-            if (cause instanceof SSLHandshakeException || cause instanceof SSLKeyException || cause instanceof SSLPeerUnverifiedException) {
+            SSLException sslException = (SSLException) e;
+            if (sslException instanceof SSLHandshakeException || sslException instanceof SSLKeyException || sslException instanceof SSLPeerUnverifiedException) {
                 // deterministic SSL exceptions
-                throw new TDClientSSLException(cause);
+                throw new TDClientSSLException(sslException);
             }
             else {
                 // SSLProtocolException and uncategorized SSL exceptions (SSLException) such as unexpected_message may be retryable
-                return Optional.<TDClientException>of(new TDClientSSLException(cause));
+                return Optional.<TDClientException>of(new TDClientSSLException(sslException));
             }
         }
         else if (e.getCause() != null && e.getCause() instanceof Exception) {

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -286,7 +286,15 @@ public class TDHttpClient
 
         request = setTDAuthHeaders(request, dateHeader);
 
-        // Set API Key
+        // Set other headers
+        for (Map.Entry<String, String> entry : headers.entries()) {
+            request = request.header(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<String, String> entry : apiRequest.getHeaderParams().entries()) {
+            request = request.header(entry.getKey(), entry.getValue());
+        }
+
+        // Set API Key after setting the other headers
         Optional<String> apiKey = apiKeyCache.or(config.apiKey);
         if (apiKey.isPresent()) {
             String auth;
@@ -297,14 +305,6 @@ public class TDHttpClient
                 auth = apiKey.get();
             }
             request = request.header(AUTHORIZATION, auth);
-        }
-
-        // Set other headers
-        for (Map.Entry<String, String> entry : headers.entries()) {
-            request = request.addHeader(entry.getKey(), entry.getValue());
-        }
-        for (Map.Entry<String, String> entry : apiRequest.getHeaderParams().entries()) {
-            request = request.addHeader(entry.getKey(), entry.getValue());
         }
 
         // Submit method specific headers

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -384,7 +384,7 @@ public class TDHttpClient
     protected Optional<TDClientException> handleError(Throwable e)
             throws TDClientException
     {
-        if (e instanceof Exception) {
+        if (Exception.class.isAssignableFrom(e.getClass())) {
             return handleException((Exception) e);
         }
         else {
@@ -399,7 +399,7 @@ public class TDHttpClient
     protected Optional<TDClientException> handleException(Exception e)
             throws TDClientException
     {
-        if (e instanceof TDClientException) {
+        if (TDClientException.class.isAssignableFrom(e.getClass())) {
             // If the error is known error, we should throw it as is
             throw (TDClientException) e;
         }
@@ -438,7 +438,7 @@ public class TDHttpClient
                 return Optional.<TDClientException>of(new TDClientSSLException(sslException));
             }
         }
-        else if (e.getCause() != null && e.getCause() instanceof Exception) {
+        else if (e.getCause() != null && Exception.class.isAssignableFrom(e.getCause().getClass())) {
             return handleError((Exception) e.getCause());
         }
         else {

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -405,6 +405,9 @@ public class TDHttpClient
                 if(e instanceof TDClientException) {
                     throw (TDClientException) e;
                 }
+                else if (e.getCause() instanceof TDClientException) {
+                    throw (TDClientException) e.getCause();
+                }
                 else if (e.getCause() instanceof EOFException) {
                     // Jetty returns EOFException when the connection was interrupted
                     context.rootCause = Optional.<TDClientException>of(new TDClientInterruptedException("connection failure (EOFException)", (EOFException) e.getCause()));

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -78,7 +78,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
+import static com.google.common.net.HttpHeaders.DATE;
 import static com.google.common.net.HttpHeaders.LOCATION;
+import static com.google.common.net.HttpHeaders.RETRY_AFTER;
+import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static com.treasuredata.client.TDApiRequest.urlEncode;
 import static com.treasuredata.client.TDClientException.ErrorType.CLIENT_ERROR;
 import static com.treasuredata.client.TDClientException.ErrorType.INVALID_INPUT;
@@ -274,8 +279,8 @@ public class TDHttpClient
         Request.Builder request =
                 new Request.Builder()
                         .url(requestUri)
-                        .header("User-Agent", getClientName())
-                        .header("Date", dateHeader);
+                        .header(USER_AGENT, getClientName())
+                        .header(DATE, dateHeader);
 
         request = setTDAuthHeaders(request, dateHeader);
 
@@ -289,7 +294,7 @@ public class TDHttpClient
             else {
                 auth = apiKey.get();
             }
-            request = request.header("Authorization", auth);
+            request = request.header(AUTHORIZATION, auth);
         }
 
         // Set other headers
@@ -318,7 +323,7 @@ public class TDHttpClient
                 else {
                     // We should set content-length explicitly for an empty post
                     request = request
-                            .header("Content-Length", "0")
+                            .header(CONTENT_LENGTH, "0")
                             .post(RequestBody.create(null, ""));
                 }
                 break;
@@ -559,7 +564,7 @@ public class TDHttpClient
     @VisibleForTesting
     static Date parseRetryAfter(long now, Response response)
     {
-        String retryAfter = response.header("Retry-After");
+        String retryAfter = response.header(RETRY_AFTER);
         if (retryAfter == null) {
             return null;
         }

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -402,7 +402,7 @@ public class TDHttpClient
             }
             catch (Exception e) {
                 logger.warn("API request failed", e);
-                if(e instanceof TDClientException) {
+                if (e instanceof TDClientException) {
                     throw (TDClientException) e;
                 }
                 else if (e.getCause() instanceof TDClientException) {
@@ -715,12 +715,14 @@ public class TDHttpClient
 
         /**
          * Send the request through the given client.
+         *
          * @param httpClient
          * @param request
          * @return
          * @throws IOException
          */
-        Response send(OkHttpClient httpClient, Request request) throws IOException;
+        Response send(OkHttpClient httpClient, Request request)
+                throws IOException;
 
         Result onSuccess(Response response)
                 throws Exception;
@@ -772,7 +774,6 @@ public class TDHttpClient
     public static class StringContentHandler
             extends DefaultHandler<String>
     {
-
         @Override
         public String onSuccess(Response response)
                 throws Exception

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -31,31 +31,18 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.io.ByteStreams;
-import com.treasuredata.client.impl.ProxyAuthResult;
+import com.treasuredata.client.impl.ProxyAuthenticator;
 import com.treasuredata.client.model.JsonCollectionRootName;
 import com.treasuredata.client.model.TDApiErrorMessage;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.HttpProxy;
-import org.eclipse.jetty.client.HttpResponseException;
-import org.eclipse.jetty.client.Origin;
-import org.eclipse.jetty.client.api.ContentResponse;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.client.api.Response;
-import org.eclipse.jetty.client.util.FutureResponseListener;
-import org.eclipse.jetty.client.util.InputStreamResponseListener;
-import org.eclipse.jetty.client.util.StringContentProvider;
-import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.util.HttpCookieStore;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import okhttp3.ConnectionPool;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,8 +56,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.BindException;
 import java.net.ConnectException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.InetSocketAddress;
 import java.net.NoRouteToHostException;
 import java.net.PortUnreachableException;
+import java.net.Proxy;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
@@ -80,12 +71,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.treasuredata.client.TDApiRequest.urlEncode;
 import static com.treasuredata.client.TDClientException.ErrorType.CLIENT_ERROR;
@@ -118,64 +107,55 @@ public class TDHttpClient
     private static final Pattern NAKED_TD1_KEY_PATTERN = Pattern.compile("^(?:[1-9][0-9]*/)?[a-f0-9]{40}$");
 
     protected final TDClientConfig config;
-    private final HttpClient httpClient;
+    private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
 
-    @VisibleForTesting
-    final Multimap<String, String> headers;
+    @VisibleForTesting final Multimap<String, String> headers;
 
     public TDHttpClient(TDClientConfig config)
     {
         this.config = config;
-        this.httpClient = config.useSSL ? new HttpClient(new SslContextFactory()) : new HttpClient();
-        this.headers = config.headers;
-        httpClient.setConnectTimeout(config.connectTimeoutMillis);
-        httpClient.setIdleTimeout(config.idleTimeoutMillis);
-        httpClient.setTCPNoDelay(true);
-        QueuedThreadPool executor = new QueuedThreadPool(config.connectionPoolSize, 2);
-        executor.setDaemon(true);
-        executor.setName("td-client");
-        httpClient.setExecutor(executor);
-        httpClient.setScheduler(new ScheduledExecutorScheduler("td-client-scheduler", true));
-        httpClient.setCookieStore(new HttpCookieStore.Empty());
-        httpClient.setUserAgentField(new HttpField(HttpHeader.USER_AGENT, "td-client-java-" + TDClient.getVersion()));
-        if (config.requestBufferSize.isPresent()) {
-            httpClient.setRequestBufferSize(config.requestBufferSize.get());
-        }
-        if (config.responseBufferSize.isPresent()) {
-            httpClient.setResponseBufferSize(config.responseBufferSize.get());
-        }
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        builder.connectTimeout(config.connectTimeoutMillis, TimeUnit.MILLISECONDS);
+        builder.readTimeout(config.readTimeoutMillis, TimeUnit.MILLISECONDS);
+        CookieManager cookieManager = new CookieManager(null, CookiePolicy.ACCEPT_ORIGINAL_SERVER);
+        builder.cookieJar(new JavaNetCookieJar(cookieManager));
 
         // Proxy configuration
         if (config.proxy.isPresent()) {
             final ProxyConfig proxyConfig = config.proxy.get();
             logger.trace("proxy configuration: " + proxyConfig);
-            HttpProxy httpProxy = new HttpProxy(new Origin.Address(proxyConfig.getHost(), proxyConfig.getPort()), proxyConfig.useSSL());
+            // TODO Support https proxy
+            builder.proxy(new Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved(proxyConfig.getHost(), proxyConfig.getPort())));
 
-            // Do not proxy requests for the proxy server
-            httpProxy.getExcludedAddresses().add(proxyConfig.getHost() + ":" + proxyConfig.getPort());
-            httpClient.getProxyConfiguration().getProxies().add(httpProxy);
             if (proxyConfig.requireAuthentication()) {
-                httpClient.getAuthenticationStore().addAuthenticationResult(new ProxyAuthResult(proxyConfig));
+                builder.proxyAuthenticator(new ProxyAuthenticator(proxyConfig));
             }
         }
+        // connection pool
+        ConnectionPool connectionPool = new ConnectionPool(config.connectionPoolSize, 5, TimeUnit.MINUTES);
+        builder.connectionPool(connectionPool);
+
+        // Build OkHttpClient
+        this.httpClient = builder.build();
+        this.headers = ImmutableMultimap.copyOf(config.headers);
+
+//        if (config.requestBufferSize.isPresent()) {
+//            httpClient.setRequestBufferSize(config.requestBufferSize.get());
+//        }
+//        if (config.responseBufferSize.isPresent()) {
+//            httpClient.setResponseBufferSize(config.responseBufferSize.get());
+//        }
+
         // Prepare jackson json-object mapper
         this.objectMapper = new ObjectMapper()
                 .registerModule(new JsonOrgModule()) // for mapping query json strings into JSONObject
                 .registerModule(new GuavaModule())   // for mapping to Guava Optional class
                 .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, false)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-        try {
-            httpClient.start();
-        }
-        catch (Exception e) {
-            logger.error("Failed to initialize Jetty client", e);
-            throw Throwables.propagate(e);
-        }
     }
 
-    private TDHttpClient(TDClientConfig config, HttpClient httpClient, ObjectMapper objectMapper, Multimap<String, String> headers)
+    private TDHttpClient(TDClientConfig config, OkHttpClient httpClient, ObjectMapper objectMapper, Multimap<String, String> headers)
     {
         this.config = config;
         this.httpClient = httpClient;
@@ -186,6 +166,7 @@ public class TDHttpClient
     /**
      * Get a {@link TDHttpClient} that uses the specified headers for each request. Reuses the same
      * underlying http client so closing the returned instance will return this instance as well.
+     *
      * @param headers
      * @return
      */
@@ -205,15 +186,7 @@ public class TDHttpClient
 
     public void close()
     {
-        synchronized (this) {
-            try {
-                httpClient.stop();
-            }
-            catch (Exception e) {
-                logger.error("Failed to terminate Jetty client", e);
-                throw Throwables.propagate(e);
-            }
-        }
+        // No need to close OkHttp client
     }
 
     @VisibleForTesting
@@ -246,16 +219,25 @@ public class TDHttpClient
                 }
             };
 
-    protected Request setTDAuthHeaders(Request request, String dateHeader)
+    protected Request.Builder setTDAuthHeaders(Request.Builder request, String dateHeader)
     {
         // Do nothing
         return request;
     }
 
+    /**
+     * Making this protected to allow overiding this value
+     *
+     * @return
+     */
     protected String getClientName()
     {
         return "td-client-java " + TDClient.getVersion();
     }
+
+    private static MediaType mediaTypeJson = MediaType.parse("application/json");
+    private static MediaType mediaTypeXwwwFormUrlencoded = MediaType.parse("application/x-www-form-urlencoded");
+    private static MediaType mediaTypeOctetStream = MediaType.parse("application/octet-stream");
 
     public Request prepareRequest(TDApiRequest apiRequest, Optional<String> apiKeyCache)
     {
@@ -276,20 +258,19 @@ public class TDHttpClient
                 queryParamList.add(String.format("%s=%s", urlEncode(queryParam.getKey()), urlEncode(queryParam.getValue())));
             }
             queryStr = Joiner.on("&").join(queryParamList);
-            if (apiRequest.getMethod() == HttpMethod.GET ||
-                    (apiRequest.getMethod() == HttpMethod.POST && apiRequest.getPostJson().isPresent())) {
+            if (apiRequest.getMethod() == TDHttpMethod.GET ||
+                    (apiRequest.getMethod() == TDHttpMethod.POST && apiRequest.getPostJson().isPresent())) {
                 requestUri += "?" + queryStr;
             }
         }
 
         logger.debug("Sending API request to {}", requestUri);
         String dateHeader = RFC2822_FORMAT.get().format(new Date());
-        Request request = httpClient.newRequest(requestUri)
-                .agent(getClientName())
-                .scheme(config.useSSL ? "https" : "http")
-                .method(apiRequest.getMethod())
-                .header(HttpHeader.DATE, dateHeader)
-                .timeout(config.requestTimeoutMillis, TimeUnit.MILLISECONDS);
+        Request.Builder request =
+                new Request.Builder()
+                        .url(requestUri)
+                        .header("User-Agent", getClientName())
+                        .header("Date", dateHeader);
 
         request = setTDAuthHeaders(request, dateHeader);
 
@@ -303,7 +284,7 @@ public class TDHttpClient
             else {
                 auth = apiKey.get();
             }
-            request.header(HttpHeader.AUTHORIZATION, auth);
+            request.header("Authorization", auth);
         }
 
         // Set other headers
@@ -316,37 +297,37 @@ public class TDHttpClient
 
         // Submit method specific headers
         switch (apiRequest.getMethod()) {
+            case GET:
+                request = request.get();
+            case DELETE:
+                request = request.delete();
             case POST:
                 if (apiRequest.getPostJson().isPresent()) {
-                    request.content(new StringContentProvider(apiRequest.getPostJson().get()), "application/json");
+                    request = request.post(RequestBody.create(mediaTypeJson, apiRequest.getPostJson().get()));
                 }
                 else if (queryStr.length() > 0) {
-                    request.content(new StringContentProvider(queryStr), "application/x-www-form-urlencoded");
+                    request = request.post(RequestBody.create(mediaTypeXwwwFormUrlencoded, queryStr));
                 }
                 else {
                     // We should set content-length explicitly for an empty post
-                    request.header("Content-Length", "0");
+                    request = request.header("Content-Length", "0");
                 }
                 break;
             case PUT:
                 if (apiRequest.getPutFile().isPresent()) {
                     try {
-                        request.file(apiRequest.getPutFile().get().toPath(), "application/octet-stream");
+                        request = request.put(RequestBody.create(mediaTypeOctetStream, apiRequest.getPutFile().get()));
                     }
-                    catch (IOException e) {
+                    catch (NullPointerException e) {
                         throw new TDClientException(TDClientException.ErrorType.INVALID_INPUT, "Failed to read input file: " + apiRequest.getPutFile().get());
                     }
                 }
                 break;
         }
 
-        // Configure redirect (302) following
-        Optional<Boolean> followRedirects = apiRequest.getFollowRedirects();
-        if (followRedirects.isPresent()) {
-            request.followRedirects(followRedirects.get());
-        }
+        // OkHttp will follow redirect (302)
 
-        return request;
+        return request.build();
     }
 
     private static boolean isNakedTD1Key(String s)
@@ -371,8 +352,8 @@ public class TDHttpClient
                 ResponseType response = null;
                 try {
                     Request request = prepareRequest(apiRequest, apiKeyCache);
-                    response = handler.submit(request);
-                    int code = response.getStatus();
+                    response = handler.submit(httpClient, request);
+                    int code = response.code();
                     if (handler.isSuccess(response)) {
                         // 2xx success
                         logger.debug(String.format("[%d:%s] API request to %s has succeeded", code, HttpStatus.getMessage(code), apiRequest.getPath()));
@@ -383,56 +364,47 @@ public class TDHttpClient
                         rootCause = Optional.of(handleHttpResponseError(apiRequest.getPath(), code, returnedContent, response));
                     }
                 }
-                catch (ExecutionException e) {
+                catch (IOException e) {
                     logger.warn("API request failed", e);
-                    // Jetty client + jersey may return ProcessingException for 401 errors
-                    Optional<HttpResponseException> responseError = findHttpResponseException(e);
-                    if (responseError.isPresent()) {
-                        HttpResponseException re = responseError.get();
-                        int code = re.getResponse().getStatus();
-                        throw handleHttpResponseError(apiRequest.getPath(), code, new byte[] {}, re.getResponse());
+                    if (e.getCause() instanceof EOFException) {
+                        // Jetty returns EOFException when the connection was interrupted
+                        rootCause = Optional.<TDClientException>of(new TDClientInterruptedException("connection failure (EOFException)", (EOFException) e.getCause()));
                     }
-                    else {
-                        if (e.getCause() instanceof EOFException) {
-                            // Jetty returns EOFException when the connection was interrupted
-                            rootCause = Optional.<TDClientException>of(new TDClientInterruptedException("connection failure (EOFException)", (EOFException) e.getCause()));
-                        }
-                        else if (e.getCause() instanceof TimeoutException) {
-                            rootCause = Optional.<TDClientException>of(new TDClientTimeoutException((TimeoutException) e.getCause()));
-                        }
-                        else if (e.getCause() instanceof SocketException) {
-                            final SocketException causeSocket = (SocketException) e.getCause();
-                            if (causeSocket instanceof BindException ||
+                    else if (e.getCause() instanceof TimeoutException) {
+                        rootCause = Optional.<TDClientException>of(new TDClientTimeoutException((TimeoutException) e.getCause()));
+                    }
+                    else if (e.getCause() instanceof SocketException) {
+                        final SocketException causeSocket = (SocketException) e.getCause();
+                        if (causeSocket instanceof BindException ||
                                 causeSocket instanceof ConnectException ||
                                 causeSocket instanceof NoRouteToHostException ||
                                 causeSocket instanceof PortUnreachableException) {
-                                // All known SocketException are retryable.
-                                rootCause = Optional.<TDClientException>of(new TDClientSocketException(causeSocket));
-                            }
-                            else {
-                                // Other unknown SocketException are considered non-retryable.
-                                throw new TDClientSocketException(causeSocket);
-                            }
-                        }
-                        else if (e.getCause() instanceof SSLException) {
-                            SSLException cause = (SSLException) e.getCause();
-                            if (cause instanceof SSLHandshakeException || cause instanceof SSLKeyException || cause instanceof SSLPeerUnverifiedException) {
-                                // deterministic SSL exceptions
-                                throw new TDClientSSLException(cause);
-                            }
-                            else {
-                                // SSLProtocolException and uncategorized SSL exceptions (SSLException) such as unexpected_message may be retryable
-                                rootCause = Optional.<TDClientException>of(new TDClientSSLException(cause));
-                            }
+                            // All known SocketException are retryable.
+                            rootCause = Optional.<TDClientException>of(new TDClientSocketException(causeSocket));
                         }
                         else {
-                            throw new TDClientProcessingException(e);
+                            // Other unknown SocketException are considered non-retryable.
+                            throw new TDClientSocketException(causeSocket);
                         }
                     }
-                }
-                catch (TimeoutException e) {
-                    logger.warn(String.format("API request to %s has timed out", apiRequest.getPath()), e);
-                    rootCause = Optional.<TDClientException>of(new TDClientTimeoutException(e));
+                    else if (e.getCause() instanceof SSLException) {
+                        SSLException cause = (SSLException) e.getCause();
+                        if (cause instanceof SSLHandshakeException || cause instanceof SSLKeyException || cause instanceof SSLPeerUnverifiedException) {
+                            // deterministic SSL exceptions
+                            throw new TDClientSSLException(cause);
+                        }
+                        else {
+                            // SSLProtocolException and uncategorized SSL exceptions (SSLException) such as unexpected_message may be retryable
+                            rootCause = Optional.<TDClientException>of(new TDClientSSLException(cause));
+                        }
+                    }
+                    else if (e.getCause() instanceof TimeoutException) {
+                        logger.warn(String.format("API request to %s has timed out", apiRequest.getPath()), e);
+                        rootCause = Optional.<TDClientException>of(new TDClientTimeoutException(e));
+                    }
+                    else {
+                        throw new TDClientProcessingException(e);
+                    }
                 }
             }
         }
@@ -513,7 +485,7 @@ public class TDHttpClient
     @VisibleForTesting
     static Date parseRetryAfter(long now, Response response)
     {
-        String retryAfter = response.getHeaders().get("Retry-After");
+        String retryAfter = response.header("Retry-After");
         if (retryAfter == null) {
             return null;
         }
@@ -547,35 +519,25 @@ public class TDHttpClient
         return String.valueOf(conflictsWith);
     }
 
-    protected static Optional<HttpResponseException> findHttpResponseException(Throwable e)
-    {
-        if (e == null) {
-            return Optional.absent();
-        }
-        else {
-            if (HttpResponseException.class.isAssignableFrom(e.getClass())) {
-                return Optional.of((HttpResponseException) e);
-            }
-            else {
-                return findHttpResponseException(e.getCause());
-            }
-        }
-    }
-
     public String call(TDApiRequest apiRequest, Optional<String> apiKeyCache)
     {
-        ContentResponse response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler(config.maxContentLength));
-        String content = response.getContentAsString();
-        if (logger.isTraceEnabled()) {
-            logger.trace("response:\n{}", content);
+        Response response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler(config.maxContentLength));
+        try {
+            String content = response.body().string();
+            if (logger.isTraceEnabled()) {
+                logger.trace("response:\n{}", content);
+            }
+            return content;
         }
-        return content;
+        catch (IOException e) {
+            throw new TDClientException(INVALID_JSON_RESPONSE, e);
+        }
     }
 
     public <Result> Result call(TDApiRequest apiRequest, Optional<String> apiKeyCache, final Function<InputStream, Result> contentStreamHandler)
     {
-        InputStream input = submitRequest(apiRequest, apiKeyCache, new ContentStreamHandler());
-        return contentStreamHandler.apply(input);
+        Response response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler());
+        return contentStreamHandler.apply(response.body().byteStream());
     }
 
     /**
@@ -625,8 +587,8 @@ public class TDHttpClient
             throws TDClientException
     {
         try {
-            ContentResponse response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler(config.maxContentLength));
-            byte[] content = response.getContent();
+            Response response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler(config.maxContentLength));
+            byte[] content = response.body().bytes();
             if (logger.isTraceEnabled()) {
                 logger.trace("response:\n{}", new String(content, StandardCharsets.UTF_8));
             }
@@ -666,8 +628,8 @@ public class TDHttpClient
 
     public static interface Handler<ResponseType extends Response, Result>
     {
-        ResponseType submit(Request request)
-                throws InterruptedException, ExecutionException, TimeoutException;
+        ResponseType submit(OkHttpClient client, Request request)
+                throws IOException;
 
         Result onSuccess(ResponseType response);
 
@@ -680,46 +642,8 @@ public class TDHttpClient
         boolean isSuccess(ResponseType response);
     }
 
-    class ContentStreamHandler
-            implements Handler<Response, InputStream>
-    {
-        private InputStreamResponseListener listner = null;
-
-        public Response submit(Request request)
-                throws InterruptedException, ExecutionException, TimeoutException
-        {
-            listner = new InputStreamResponseListener();
-            request.send(listner);
-            long timeout = httpClient.getIdleTimeout();
-            return listner.get(timeout, TimeUnit.MILLISECONDS);
-        }
-
-        public InputStream onSuccess(Response response)
-        {
-            checkNotNull(listner, "listener is null");
-            return listner.getInputStream();
-        }
-
-        public byte[] onError(Response response)
-        {
-            try (InputStream in = listner.getInputStream()) {
-                byte[] errorResponse = ByteStreams.toByteArray(in);
-                return errorResponse;
-            }
-            catch (IOException e) {
-                throw new TDClientException(INVALID_JSON_RESPONSE, e);
-            }
-        }
-
-        @Override
-        public boolean isSuccess(Response response)
-        {
-            return HttpStatus.isSuccess(response.getStatus());
-        }
-    }
-
     public static class DefaultContentHandler
-            implements Handler<ContentResponse, ContentResponse>
+            implements Handler<Response, Response>
     {
         protected final Optional<Integer> maxContentLength;
 
@@ -734,43 +658,33 @@ public class TDHttpClient
         }
 
         @Override
-        public ContentResponse submit(Request request)
-                throws InterruptedException, ExecutionException, TimeoutException
+        public Response submit(OkHttpClient client, Request request)
+                throws IOException
         {
-            FutureResponseListener listener = maxContentLength.isPresent() ? new FutureResponseListener(request, maxContentLength.get()) : new FutureResponseListener(request);
-            request.send(listener);
-
-            try {
-                long timeout = request.getTimeout();
-                if (timeout <= 0) {
-                    return listener.get();
-                }
-                return listener.get(timeout, TimeUnit.MILLISECONDS);
-            }
-            catch (Throwable throwable) {
-                // Differently from the Future, the semantic of this method is that if
-                // the send() is interrupted or times out, we abort the request.
-                request.abort(throwable);
-                throw throwable;
-            }
+            return client.newCall(request).execute();
         }
 
         @Override
-        public ContentResponse onSuccess(ContentResponse response)
+        public Response onSuccess(Response response)
         {
             return response;
         }
 
         @Override
-        public byte[] onError(ContentResponse response)
+        public byte[] onError(Response response)
         {
-            return response.getContent();
+            try {
+                return response.body().bytes();
+            }
+            catch (IOException e) {
+                throw new TDClientException(INVALID_JSON_RESPONSE, e);
+            }
         }
 
         @Override
-        public boolean isSuccess(ContentResponse response)
+        public boolean isSuccess(Response response)
         {
-            return HttpStatus.isSuccess(response.getStatus());
+            return HttpStatus.isSuccess(response.code());
         }
     }
 }

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -382,7 +382,7 @@ public class TDHttpClient
                         }
                     }
 
-                    ResponseContext responseContext = new ResponseContext(this, context.apiRequest, response);
+                    ResponseContext responseContext = new ResponseContext(context.apiRequest, response);
                     if (handler.isSuccess(responseContext)) {
                         // 2xx success
                         logger.debug(String.format("[%d:%s] API request to %s has succeeded", code, HttpStatus.getMessage(code), context.apiRequest.getPath()));

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -521,7 +521,7 @@ public class TDHttpClient
 
     public String call(TDApiRequest apiRequest, Optional<String> apiKeyCache)
     {
-        Response response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler(config.maxContentLength));
+        Response response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler());
         try {
             String content = response.body().string();
             if (logger.isTraceEnabled()) {
@@ -587,7 +587,7 @@ public class TDHttpClient
             throws TDClientException
     {
         try {
-            Response response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler(config.maxContentLength));
+            Response response = submitRequest(apiRequest, apiKeyCache, new DefaultContentHandler());
             byte[] content = response.body().bytes();
             if (logger.isTraceEnabled()) {
                 logger.trace("response:\n{}", new String(content, StandardCharsets.UTF_8));
@@ -645,16 +645,8 @@ public class TDHttpClient
     public static class DefaultContentHandler
             implements Handler<Response, Response>
     {
-        protected final Optional<Integer> maxContentLength;
-
         public DefaultContentHandler()
         {
-            this(Optional.<Integer>absent());
-        }
-
-        public DefaultContentHandler(Optional<Integer> maxContentLength)
-        {
-            this.maxContentLength = maxContentLength;
         }
 
         @Override

--- a/src/main/java/com/treasuredata/client/TDHttpMethod.java
+++ b/src/main/java/com/treasuredata/client/TDHttpMethod.java
@@ -1,0 +1,11 @@
+package com.treasuredata.client;
+
+/**
+ *
+ */
+public enum TDHttpMethod {
+    GET,
+    POST,
+    PUT,
+    DELETE;
+}

--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
@@ -17,13 +17,11 @@ public interface TDHttpRequestHandler<Result>
 {
     static class ResponseContext
     {
-        public final TDHttpClient client;
         public final TDApiRequest apiRequest;
         public final Response response;
 
-        public ResponseContext(TDHttpClient client, TDApiRequest apiRequest, Response response)
+        public ResponseContext(TDApiRequest apiRequest, Response response)
         {
-            this.client = client;
             this.apiRequest = apiRequest;
             this.response = response;
         }

--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
@@ -1,0 +1,80 @@
+package com.treasuredata.client;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+import static com.treasuredata.client.TDClientException.ErrorType.INVALID_JSON_RESPONSE;
+
+/**
+ *
+ */
+public interface TDHttpRequestHandler<Result>
+{
+    /**
+     * Set additional request parameters here.
+     *
+     * @param request
+     * @return
+     */
+    default Request prepareRequest(Request request)
+    {
+        // Do nothing by default
+        return request;
+    }
+
+    /**
+     * If this returns true, onSuccess(resposne) will be called
+     *
+     * @param response
+     * @return
+     */
+    default boolean isSuccess(Response response)
+    {
+        // Just check 200 <= code < 300 range
+        return response.isSuccessful();
+    }
+
+    /**
+     * Send the request through the given client.
+     *
+     * @param httpClient
+     * @param request
+     * @return
+     * @throws IOException
+     */
+    default Response send(OkHttpClient httpClient, Request request)
+            throws IOException
+    {
+        return httpClient.newCall(request).execute();
+    }
+
+    /**
+     * Handle the response
+     *
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    Result onSuccess(Response response)
+            throws Exception;
+
+    /**
+     * When isSuccess(response) returns false, this method will be called to read the returned response.
+     *
+     * @param response
+     * @return returned content
+     */
+    default byte[] onError(Response response)
+            throws IOException
+    {
+        try {
+            return response.body().bytes();
+        }
+        catch (IOException e) {
+            throw new TDClientException(INVALID_JSON_RESPONSE, e);
+        }
+    }
+}

--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
@@ -7,8 +7,8 @@ import okhttp3.Response;
 import java.io.IOException;
 
 import static com.treasuredata.client.TDClientException.ErrorType.INVALID_JSON_RESPONSE;
-import static com.treasuredata.client.TDRequestErrorHandler.defaultErrorHandler;
-import static com.treasuredata.client.TDRequestErrorHandler.defaultHttpResponseHandler;
+import static com.treasuredata.client.TDRequestErrorHandler.defaultErrorResolver;
+import static com.treasuredata.client.TDRequestErrorHandler.defaultHttpResponseErrorResolver;
 
 /**
  *
@@ -87,7 +87,7 @@ public interface TDHttpRequestHandler<Result>
     default TDClientException resolveHttpResponseError(ResponseContext responseContext)
             throws TDClientException
     {
-        return defaultHttpResponseHandler.apply(responseContext);
+        return defaultHttpResponseErrorResolver(responseContext);
     }
 
     /**
@@ -100,7 +100,7 @@ public interface TDHttpRequestHandler<Result>
     default TDClientException resolveError(Throwable e)
             throws TDClientException
     {
-        return defaultErrorHandler.apply(e);
+        return defaultErrorResolver(e);
     }
 
     /**

--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
@@ -15,7 +15,7 @@ public class TDHttpRequestHandlers
     {
     }
 
-    public static TDHttpRequestHandler<String> stringContentHandler = new TDHttpRequestHandler<String>()
+    public static final TDHttpRequestHandler<String> stringContentHandler = new TDHttpRequestHandler<String>()
     {
         @Override
         public String onSuccess(Response response)
@@ -25,7 +25,7 @@ public class TDHttpRequestHandlers
         }
     };
 
-    public static TDHttpRequestHandler<byte[]> byteArrayContentHandler = new TDHttpRequestHandler<byte[]>()
+    public static final TDHttpRequestHandler<byte[]> byteArrayContentHandler = new TDHttpRequestHandler<byte[]>()
     {
         @Override
         public byte[] onSuccess(Response response)
@@ -35,7 +35,7 @@ public class TDHttpRequestHandlers
         }
     };
 
-    public static <Result> TDHttpRequestHandler<Result> newByteStreamHandler(final Function<InputStream, Result> handler)
+    public static final <Result> TDHttpRequestHandler<Result> newByteStreamHandler(final Function<InputStream, Result> handler)
     {
         return new TDHttpRequestHandler<Result>()
         {

--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
@@ -1,0 +1,52 @@
+package com.treasuredata.client;
+
+import com.google.common.base.Function;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.InputStream;
+
+/**
+ * Request handler implementations
+ */
+public class TDHttpRequestHandlers
+{
+    private TDHttpRequestHandlers()
+    {
+    }
+
+    public static TDHttpRequestHandler<String> stringContentHandler = new TDHttpRequestHandler<String>()
+    {
+        @Override
+        public String onSuccess(Response response)
+                throws Exception
+        {
+            return response.body().string();
+        }
+    };
+
+    public static TDHttpRequestHandler<byte[]> byteArrayContentHandler = new TDHttpRequestHandler<byte[]>()
+    {
+        @Override
+        public byte[] onSuccess(Response response)
+                throws Exception
+        {
+            return response.body().bytes();
+        }
+    };
+
+    public static <Result> TDHttpRequestHandler<Result> newByteStreamHandler(final Function<InputStream, Result> handler)
+    {
+        return new TDHttpRequestHandler<Result>()
+        {
+            @Override
+            public Result onSuccess(Response response)
+                    throws Exception
+            {
+                try (ResponseBody body = response.body()) {
+                    return handler.apply(body.byteStream());
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -1,0 +1,247 @@
+package com.treasuredata.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.treasuredata.client.model.TDApiErrorMessage;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLKeyException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.BindException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.PortUnreachableException;
+import java.net.ProtocolException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static com.google.common.net.HttpHeaders.RETRY_AFTER;
+import static com.treasuredata.client.TDClientException.ErrorType.CLIENT_ERROR;
+import static com.treasuredata.client.TDClientException.ErrorType.INVALID_INPUT;
+import static com.treasuredata.client.TDClientException.ErrorType.INVALID_JSON_RESPONSE;
+import static com.treasuredata.client.TDClientException.ErrorType.PROXY_AUTHENTICATION_FAILURE;
+import static com.treasuredata.client.TDClientException.ErrorType.SERVER_ERROR;
+import static com.treasuredata.client.TDClientException.ErrorType.UNEXPECTED_RESPONSE_CODE;
+import static com.treasuredata.client.TDClientHttpTooManyRequestsException.TOO_MANY_REQUESTS_429;
+import static com.treasuredata.client.TDHttpRequestHandler.ResponseContext;
+
+/**
+ * TDRequestErrorHandler has a logic to handle http request retris,
+ */
+public class TDRequestErrorHandler
+{
+    private TDRequestErrorHandler()
+    {
+    }
+
+    // Use TDHttpClient's logger for better log messages
+    private static Logger logger = LoggerFactory.getLogger(TDHttpClient.class);
+
+    @VisibleForTesting
+    static final ThreadLocal<SimpleDateFormat> HTTP_DATE_FORMAT = new ThreadLocal<SimpleDateFormat>()
+    {
+        @Override
+        protected SimpleDateFormat initialValue()
+        {
+            return new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+        }
+    };
+
+    public static Function<ResponseContext, TDClientException> defaultHttpResponseHandler = new Function<ResponseContext, TDClientException>()
+    {
+        @Override
+        public TDClientException apply(ResponseContext responseContext)
+        {
+            Response response = responseContext.response;
+            int code = response.code();
+            long now = System.currentTimeMillis();
+
+            Date retryAfter = parseRetryAfter(now, response);
+            Optional<TDApiErrorMessage> errorResponse = extractErrorResponse(responseContext);
+            String responseErrorText = errorResponse.isPresent() ? ": " + errorResponse.get().getText() : "";
+            String errorMessage = String.format("[%d:%s] API request to %s has failed%s", code, HttpStatus.getMessage(code), responseContext.apiRequest.getPath(), responseErrorText);
+            if (HttpStatus.isClientError(code)) {
+                logger.debug(errorMessage);
+                switch (code) {
+                    // Soft 4xx errors. These we retry.
+                    case TOO_MANY_REQUESTS_429:
+                        return new TDClientHttpTooManyRequestsException(errorMessage, retryAfter);
+                    // Hard 4xx error. We do not retry the execution on this type of error
+                    case HttpStatus.UNAUTHORIZED_401:
+                        throw new TDClientHttpUnauthorizedException(errorMessage);
+                    case HttpStatus.NOT_FOUND_404:
+                        throw new TDClientHttpNotFoundException(errorMessage);
+                    case HttpStatus.CONFLICT_409:
+                        String conflictsWith = errorResponse.isPresent() ? parseConflictsWith(errorResponse.get()) : null;
+                        throw new TDClientHttpConflictException(errorMessage, conflictsWith);
+                    case HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407:
+                        throw new TDClientHttpException(PROXY_AUTHENTICATION_FAILURE, errorMessage, code, retryAfter);
+                    case HttpStatus.UNPROCESSABLE_ENTITY_422:
+                        throw new TDClientHttpException(INVALID_INPUT, errorMessage, code, retryAfter);
+                    default:
+                        throw new TDClientHttpException(CLIENT_ERROR, errorMessage, code, retryAfter);
+                }
+            }
+            logger.warn(errorMessage);
+            if (HttpStatus.isServerError(code)) {
+                // Just returns exception info for 5xx errors
+                return new TDClientHttpException(SERVER_ERROR, errorMessage, code, retryAfter);
+            }
+            else {
+                throw new TDClientHttpException(UNEXPECTED_RESPONSE_CODE, errorMessage, code, retryAfter);
+            }
+        }
+    };
+
+    public static Function<Throwable, TDClientException> defaultErrorHandler = new Function<Throwable, TDClientException>()
+    {
+        @Override
+        public TDClientException apply(Throwable e)
+        {
+            if (Exception.class.isAssignableFrom(e.getClass())) {
+                return handleException((Exception) e);
+            }
+            else {
+                throw new TDClientProcessingException(new RuntimeException(e));
+            }
+        }
+
+        /**
+         * @return If the error type is retryable, return the exception. If not, throw it as TDClientException
+         * @throws TDClientException
+         */
+        protected TDClientException handleException(Exception e)
+                throws TDClientException
+        {
+            if (TDClientException.class.isAssignableFrom(e.getClass())) {
+                // If the error is known error, we should throw it as is
+                throw (TDClientException) e;
+            }
+            else if (e instanceof ProtocolException || e instanceof ConnectException || e instanceof EOFException) {
+                // OkHttp throws ProtocolException the content length is insufficient
+                // ConnectionException can be throw if server is shutting down
+                // EOFException can be thrown when the connection was interrupted
+                return new TDClientInterruptedException("connection failure", e);
+            }
+            else if (e instanceof TimeoutException || e instanceof SocketTimeoutException) {
+                // OkHttp throws SocketTimeoutException
+                return new TDClientTimeoutException(e);
+            }
+            else if (e instanceof SocketException) {
+                final SocketException socketException = (SocketException) e;
+                if (socketException instanceof BindException ||
+                        socketException instanceof ConnectException ||
+                        socketException instanceof NoRouteToHostException ||
+                        socketException instanceof PortUnreachableException) {
+                    // All known SocketException are retryable.
+                    return new TDClientSocketException(socketException);
+                }
+                else {
+                    // Other unknown SocketException are considered non-retryable.
+                    throw new TDClientSocketException(socketException);
+                }
+            }
+            else if (e instanceof SSLException) {
+                SSLException sslException = (SSLException) e;
+                if (sslException instanceof SSLHandshakeException || sslException instanceof SSLKeyException || sslException instanceof SSLPeerUnverifiedException) {
+                    // deterministic SSL exceptions
+                    throw new TDClientSSLException(sslException);
+                }
+                else {
+                    // SSLProtocolException and uncategorized SSL exceptions (SSLException) such as unexpected_message may be retryable
+                    return new TDClientSSLException(sslException);
+                }
+            }
+            else if (e.getCause() != null && Exception.class.isAssignableFrom(e.getCause().getClass())) {
+                return handleException((Exception) e.getCause());
+            }
+            else {
+                logger.warn("unknown type exception: " + e.getClass(), e);
+                throw new TDClientProcessingException(e);
+            }
+        }
+    };
+
+    /**
+     * https://tools.ietf.org/html/rfc7231#section-7.1.3
+     */
+    @VisibleForTesting
+    static Date parseRetryAfter(long now, Response response)
+    {
+        String retryAfter = response.header(RETRY_AFTER);
+        if (retryAfter == null) {
+            return null;
+        }
+        // Try parsing as a number of seconds first
+        try {
+            long retryAfterSeconds = Long.parseLong(retryAfter);
+            return new Date(now + TimeUnit.SECONDS.toMillis(retryAfterSeconds));
+        }
+        catch (NumberFormatException e) {
+            // Then try parsing as a HTTP-date
+            try {
+                return HTTP_DATE_FORMAT.get().parse(retryAfter);
+            }
+            catch (ParseException ignore) {
+                logger.warn("Failed to parse Retry-After header: '" + retryAfter + "'");
+                return null;
+            }
+        }
+    }
+
+    private static String parseConflictsWith(TDApiErrorMessage errorResponse)
+    {
+        Map<String, Object> details = errorResponse.getDetails();
+        if (details == null) {
+            return null;
+        }
+        Object conflictsWith = details.get("conflicts_with");
+        if (conflictsWith == null) {
+            return null;
+        }
+        return String.valueOf(conflictsWith);
+    }
+
+    @VisibleForTesting
+    public static Optional<TDApiErrorMessage> extractErrorResponse(ResponseContext responseContext)
+    {
+        byte[] content = null;
+        try {
+            try {
+                content = responseContext.response.body().bytes();
+            }
+            catch (IOException e) {
+                throw new TDClientException(INVALID_JSON_RESPONSE, e);
+            }
+
+            if (content.length > 0 && content[0] == '{') {
+                // Error message from TD API
+                return Optional.of(responseContext.client.getObjectMapper().readValue(content, TDApiErrorMessage.class));
+            }
+            else {
+                // Error message from Proxy server etc.
+                String contentStr = new String(content, StandardCharsets.UTF_8);
+                return Optional.of(new TDApiErrorMessage("error", contentStr, "error"));
+            }
+        }
+        catch (IOException e) {
+            logger.warn(String.format("Failed to parse error response: %s", new String(content, StandardCharsets.UTF_8)), e);
+        }
+        return Optional.absent();
+    }
+}

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -221,7 +221,7 @@ public class TDRequestErrorHandler
                 throw new TDClientException(INVALID_JSON_RESPONSE, e);
             }
 
-            if (content.isPresent() && content.get().charAt(0) == '{') {
+            if (content.isPresent() && content.get().length() > 0 && content.get().charAt(0) == '{') {
                 // Error message from TD API
                 return Optional.of(TDHttpClient.defaultObjectMapper.readValue(content.get(), TDApiErrorMessage.class));
             }

--- a/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static com.google.common.net.HttpHeaders.PROXY_AUTHORIZATION;
+
 /**
  *
  */
@@ -51,7 +53,8 @@ public class ProxyAuthenticator
     public Request authenticate(Route route, Response response)
             throws IOException
     {
-        if (response.request().header("Proxy-Authorization") != null) {
+        if (response.request().header(PROXY_AUTHORIZATION) != null) {
+            // If Proxy-Authrization is set, it means OkHttp client has already tried the authentication and failed
             throw new IOException(new TDClientHttpException(TDClientException.ErrorType.PROXY_AUTHENTICATION_FAILURE, "Proxy authentication failure", 407, null));
         }
 
@@ -63,7 +66,7 @@ public class ProxyAuthenticator
             );
         }
         return response.request().newBuilder()
-                .addHeader("Proxy-Authorization", proxyAuthCache.get())
+                .addHeader(PROXY_AUTHORIZATION, proxyAuthCache.get())
                 .build();
     }
 }

--- a/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
@@ -22,7 +22,6 @@ import com.google.common.base.Optional;
 import com.treasuredata.client.ProxyConfig;
 import com.treasuredata.client.TDClientException;
 import com.treasuredata.client.TDClientHttpException;
-import com.treasuredata.client.TDHttpClient;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
 import okhttp3.Request;
@@ -52,8 +51,7 @@ public class ProxyAuthenticator
     public Request authenticate(Route route, Response response)
             throws IOException
     {
-        if (response.request().header("Proxy-Authorization") != null)
-        {
+        if (response.request().header("Proxy-Authorization") != null) {
             throw new IOException(new TDClientHttpException(TDClientException.ErrorType.PROXY_AUTHENTICATION_FAILURE, "Proxy authentication failure", 407, null));
         }
 

--- a/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
@@ -21,9 +21,7 @@ package com.treasuredata.client.impl;
 import com.google.common.base.Optional;
 import com.treasuredata.client.ProxyConfig;
 import okhttp3.Authenticator;
-import okhttp3.Challenge;
 import okhttp3.Credentials;
-import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
@@ -31,10 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.PasswordAuthentication;
-import java.net.Proxy;
-import java.util.List;
 
 /**
  *
@@ -55,7 +49,7 @@ public class ProxyAuthenticator
     public Request authenticate(Route route, Response response)
             throws IOException
     {
-        if(response.code() == 407) {
+        if (response.code() == 407) {
             // Proxy authentication is required
             if (!proxyAuthCache.isPresent()) {
                 logger.debug("Proxy authorization requested for " + route.address());

--- a/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
@@ -49,8 +49,8 @@ public class ProxyAuthenticator
     public Request authenticate(Route route, Response response)
             throws IOException
     {
-        logger.debug("Proxy authorization requested for " + route.address());
         if (!proxyAuthCache.isPresent()) {
+            logger.debug("Proxy authorization requested for " + route.address());
             proxyAuthCache = Optional.of(
                     Credentials.basic(proxyConfig.getUser().or(""), proxyConfig.getPassword().or(""))
             );

--- a/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
@@ -58,7 +58,7 @@ public class ProxyAuthenticator
                 );
             }
             return response.request().newBuilder()
-                    .header("Proxy-Authorization", proxyAuthCache.get())
+                    .addHeader("Proxy-Authorization", proxyAuthCache.get())
                     .build();
         }
         else {

--- a/src/test/java/com/treasuredata/client/TDRequestErrorHandlerTest.java
+++ b/src/test/java/com/treasuredata/client/TDRequestErrorHandlerTest.java
@@ -1,0 +1,101 @@
+package com.treasuredata.client;
+
+import com.google.common.base.Optional;
+import com.treasuredata.client.model.TDApiErrorMessage;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Instant;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ *
+ */
+public class TDRequestErrorHandlerTest
+{
+    private static Logger logger = LoggerFactory.getLogger(TestTDHttpClient.class);
+    private TDHttpClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        client = TDClient.newClient().httpClient;
+    }
+
+    @After
+    public void tearDown()
+            throws Exception
+    {
+        client.close();
+    }
+
+    @Test
+    public void parseInvalidErrorMessage()
+    {
+        Response response = new Response.Builder()
+                .request(new Request.Builder().url("https://api.treasuredata.com/v3/server_status").build())
+                .message("")
+                .code(HttpStatus.ACCEPTED_202)
+                .protocol(Protocol.HTTP_1_1)
+                .body(ResponseBody.create(MediaType.parse("application/json"), "{invalid json response}"))
+                .build();
+
+        Optional<TDApiErrorMessage> err = TDRequestErrorHandler.extractErrorResponse(response);
+        assertFalse(err.isPresent());
+    }
+
+    @Test
+    public void testParseRetryAfterHttpDate()
+            throws Exception
+    {
+        Response response = new Response.Builder()
+                .request(new Request.Builder().url("https://api.treasuredata.com/v3/server_status").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("")
+                .headers(Headers.of("Retry-After", "Fri, 31 Dec 1999 23:59:59 GMT"))
+                .build();
+
+        long now = System.currentTimeMillis();
+        Date d = TDRequestErrorHandler.parseRetryAfter(now, response);
+        Instant retryAfter = new Instant(d);
+        Instant expected = new DateTime(1999, 12, 31, 23, 59, 59, DateTimeZone.UTC).toInstant();
+        assertThat(retryAfter, is(expected));
+    }
+
+    @Test
+    public void testParseRetryAfterSeconds()
+            throws Exception
+    {
+        Response response = new Response.Builder()
+                .request(new Request.Builder().url("https://api.treasuredata.com/v3/server_status").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("")
+                .headers(Headers.of("Retry-After", "120"))
+                .build();
+
+        long now = System.currentTimeMillis();
+
+        Date d = TDRequestErrorHandler.parseRetryAfter(now, response);
+        Instant retryAfter = new Instant(d);
+        Instant expected = new DateTime(now).plusSeconds(120).toInstant();
+        assertThat(retryAfter, is(expected));
+    }
+}

--- a/src/test/java/com/treasuredata/client/TestProxyAccess.java
+++ b/src/test/java/com/treasuredata/client/TestProxyAccess.java
@@ -138,14 +138,14 @@ public class TestProxyAccess
 
         try {
             Authenticator.setDefault(auth);
-            try (InputStream in = new URL("https://api.treasuredata.com/v3/system/server_status").openConnection(proxy).getInputStream()) {
+            // Non SSL access
+            try (InputStream in = new URL("http://api.treasuredata.com/v3/system/server_status").openConnection(proxy).getInputStream()) {
                 String ret = CharStreams.toString(new InputStreamReader(in));
                 logger.info(ret);
             }
             assertEquals(1, proxyAccessCount.get());
 
-            // Non SSL access
-            try (InputStream in = new URL("http://api.treasuredata.com/v3/system/server_status").openConnection(proxy).getInputStream()) {
+            try (InputStream in = new URL("https://api.treasuredata.com/v3/system/server_status").openConnection(proxy).getInputStream()) {
                 String ret = CharStreams.toString(new InputStreamReader(in));
                 logger.info(ret);
             }

--- a/src/test/java/com/treasuredata/client/TestProxyAccess.java
+++ b/src/test/java/com/treasuredata/client/TestProxyAccess.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.littleshoot.proxy.HttpFilters;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
 import org.littleshoot.proxy.HttpProxyServer;
-import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +82,7 @@ public class TestProxyAccess
         this.proxyServer = DefaultHttpProxyServer
                 .bootstrap()
                 .withPort(proxyPort)
-                .withProxyAuthenticator(new ProxyAuthenticator()
+                .withProxyAuthenticator(new org.littleshoot.proxy.ProxyAuthenticator()
                 {
                     @Override
                     public boolean authenticate(String user, String pass)

--- a/src/test/java/com/treasuredata/client/TestSSLProxyAccess.java
+++ b/src/test/java/com/treasuredata/client/TestSSLProxyAccess.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.littleshoot.proxy.HttpFilters;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
 import org.littleshoot.proxy.HttpProxyServer;
-import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,9 +60,8 @@ public class TestSSLProxyAccess
         this.proxyServer = DefaultHttpProxyServer
                 .bootstrap()
                 .withPort(proxyPort)
-                .withProxyAuthenticator(new ProxyAuthenticator()
+                .withProxyAuthenticator(new org.littleshoot.proxy.ProxyAuthenticator()
                 {
-                    @Override
                     public boolean authenticate(String user, String pass)
                     {
                         boolean isValid = user.equals(PROXY_USER) && pass.equals(PROXY_PASS);

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -186,7 +186,7 @@ public class TestServerFailures
                 .setEndpoint("localhost")
                 .setUseSSL(false)
                 .setPort(port)
-                .setIdleTimeoutMillis(100)
+                .setReadTimeoutMillis(100)
                 .setRetryLimit(1)
                 .buildConfig()
         );

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Throwables;
 import com.google.common.io.CharStreams;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
@@ -35,7 +34,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ConnectException;
@@ -191,7 +189,6 @@ public class TestServerFailures
                 .setRetryLimit(1)
                 .buildConfig()
         );
-
     }
 
     @Test
@@ -211,7 +208,7 @@ public class TestServerFailures
     }
 
     private void handleTimeoutTest(TDClientConfig config)
-        throws Exception
+            throws Exception
     {
         final AtomicInteger accessCount = new AtomicInteger(0);
 

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -92,7 +92,7 @@ public class TestServerFailures
                     server.join();
                 }
                 catch (Throwable e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         }).start();
@@ -204,7 +204,7 @@ public class TestServerFailures
                 .setEndpoint("localhost")
                 .setUseSSL(false)
                 .setPort(port)
-                .setRequestTimeoutMillis(100)
+                .setReadTimeoutMillis(100)
                 .setRetryLimit(1)
                 .buildConfig()
         );

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.ConnectException;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -279,9 +280,9 @@ public class TestServerFailures
             fail("cannot reach here");
         }
         catch (TDClientException e) {
-            assertEquals(TDClientException.ErrorType.INTERRUPTED, e.getErrorType());
+            assertEquals(TDClientException.ErrorType.SOCKET_ERROR, e.getErrorType());
             logger.info(e.getMessage());
-            assertTrue(e.getRootCause().get() instanceof EOFException);
+            assertTrue(e.getRootCause().get() instanceof ConnectException);
             assertEquals(1, accessCount.get());
         }
     }

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -19,28 +19,25 @@
 package com.treasuredata.client;
 
 import com.google.common.io.CharStreams;
-import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import com.google.common.net.HttpHeaders;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.EOFException;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ConnectException;
 import java.net.URL;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.instanceOf;
@@ -55,89 +52,39 @@ import static org.junit.Assert.fail;
 public class TestServerFailures
 {
     private static Logger logger = LoggerFactory.getLogger(TestServerFailures.class);
-    Server server;
-    ServerConnector http;
-    int port;
 
-    private void prepareServer(int port)
-            throws Exception
-    {
-        server = new Server();
-
-        http = new ServerConnector(server);
-        http.setHost("localhost");
-        http.setPort(port);
-        server.addConnector(http);
-    }
+    private MockWebServer server;
+    private int port;
 
     @Before
     public void setUp()
             throws Exception
     {
-        // NOTICE. This jetty server does not accept SSL connection. So use http in TDClient
         port = TestProxyAccess.findAvailablePort();
-        prepareServer(port);
-    }
-
-    private void startServer()
-            throws InterruptedException
-    {
-        final AtomicBoolean ready = new AtomicBoolean(false);
-        new Thread(new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                try {
-                    server.start();
-                    ready.set(true);
-                    server.join();
-                }
-                catch (Throwable e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }).start();
-
-        ExponentialBackOff backoff = new ExponentialBackOff(10, 1000, 1.5);
-        while (!ready.get()) {
-            Thread.sleep(backoff.nextWaitTimeMillis());
-        }
+        server = new MockWebServer();
     }
 
     @After
     public void tearDown()
             throws Exception
     {
-        server.stop();
+        server.close();
     }
 
     @Test
-    public void jettyServerTest()
+    public void mockServerTest()
             throws Exception
     {
-        final AtomicInteger accessCount = new AtomicInteger(0);
-        server.setHandler(new AbstractHandler()
-        {
-            @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                    throws IOException, ServletException
-            {
-                logger.debug("request: " + request);
-                accessCount.incrementAndGet();
-                response.setStatus(HttpStatus.OK_200);
-                response.getWriter().print("hello!");
-                baseRequest.setHandled(true);
-            }
-        });
-        startServer();
+        server.enqueue(new MockResponse().setBody("hello"));
+        server.start(port);
+
         String url = String.format("http://localhost:%s/v3/system/server_status", port);
         logger.info("url: " + url);
         try (InputStreamReader reader = new InputStreamReader(new URL(url).openStream())) {
             String content = CharStreams.toString(reader);
             logger.info(content);
         }
-        assertEquals(1, accessCount.get());
+        assertEquals(1, server.getRequestCount());
     }
 
     @Test
@@ -146,21 +93,10 @@ public class TestServerFailures
     {
         logger.warn("Start request retry tests on 500 errors");
         final int retryLimit = 3;
-        final AtomicInteger accessCount = new AtomicInteger(0);
-        server.setHandler(new AbstractHandler()
-        {
-            @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                    throws IOException, ServletException
-            {
-                // Keep returning 500 error
-                logger.debug("request: " + request);
-                accessCount.incrementAndGet();
-                response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
-                baseRequest.setHandled(true);
-            }
-        });
-        startServer();
+        for (int i = 0; i < retryLimit + 1; ++i) {
+            server.enqueue(new MockResponse().setResponseCode(500));
+        }
+        server.start(port);
 
         TDClient client = TDClient
                 .newBuilder()
@@ -175,7 +111,7 @@ public class TestServerFailures
         }
         catch (TDClientHttpException e) {
             assertEquals(TDClientException.ErrorType.SERVER_ERROR, e.getErrorType());
-            assertEquals(1 + retryLimit, accessCount.get());
+            assertEquals(1 + retryLimit, server.getRequestCount());
         }
     }
 
@@ -214,60 +150,24 @@ public class TestServerFailures
     private void handleTimeoutTest(TDClientConfig config)
             throws Exception
     {
-        final AtomicInteger accessCount = new AtomicInteger(0);
-
-        server.setHandler(new AbstractHandler()
-        {
-            @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                    throws IOException, ServletException
-            {
-                logger.debug("request: " + request);
-                int count = accessCount.incrementAndGet();
-                if (count == 1) {
-                    try {
-                        Thread.sleep(1000); // 1 sec
-                    }
-                    catch (InterruptedException e) {
-                    }
-                }
-                response.setStatus(HttpStatus.OK_200);
-                response.getWriter().write("{\"server\":\"ok\"}"); // write intermediate result
-                baseRequest.setHandled(true);
-            }
-        });
-        startServer();
+        server.enqueue(new MockResponse().setBody("{\"server\":\"ok\"}").throttleBody(5, 1, TimeUnit.SECONDS));
+        server.enqueue(new MockResponse().setBody("{\"server\":\"ok\"}"));
+        server.start(port);
 
         TDClient client = new TDClient(config);
         client.serverStatus();
-        assertEquals(2, accessCount.get());
+        assertEquals(2, server.getRequestCount());
     }
 
     @Test
     public void handleEOFException()
             throws Exception
     {
-        logger.warn("Start request retry tests on connection interruption");
-        final AtomicInteger accessCount = new AtomicInteger(0);
-        server.setHandler(new AbstractHandler()
-        {
-            @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                    throws IOException, ServletException
-            {
-                logger.debug("request: " + request);
-                accessCount.incrementAndGet();
-                response.setStatus(HttpStatus.OK_200);
-                response.getWriter().write("{\"server\": "); // write intermediate result
-                try {
-                    // Shutdown the connection
-                    server.stop();
-                }
-                catch (Throwable e) {
-                }
-            }
-        });
-        startServer();
+        logger.warn("Start connection interruption test");
+        // write intermediate result
+        // Add long delay
+        server.enqueue(new MockResponse().setBody("{\"server\": ").setBodyDelay(3, TimeUnit.SECONDS));
+        server.start(port);
 
         TDClient client = TDClient
                 .newBuilder()
@@ -276,20 +176,54 @@ public class TestServerFailures
                 .setPort(port)
                 .setRetryLimit(0)
                 .build();
-        try {
-            client.serverStatus();
-            fail("cannot reach here");
-        }
-        catch (TDClientException e) {
-            logger.debug(e.getMessage());
-            if (e.getErrorType() == TDClientException.ErrorType.INTERRUPTED) {
-                assertThat(e.getRootCause().get(), anyOf(instanceOf(InterruptedException.class), instanceOf(EOFException.class)));
+
+        ExecutorService t = Executors.newFixedThreadPool(2);
+        t.submit(new Callable<Void>()
+        {
+            @Override
+            public Void call()
+                    throws Exception
+            {
+                try {
+                    logger.info("check server status");
+                    client.serverStatus();
+                    fail("should not reach here");
+                }
+                catch (TDClientException e) {
+                    logger.info("here: " + e.getMessage(), e);
+                    if (e.getErrorType() == TDClientException.ErrorType.INTERRUPTED) {
+                        assertThat(e.getRootCause().get(), anyOf(instanceOf(InterruptedException.class), instanceOf(EOFException.class)));
+                    }
+                    else {
+                        assertEquals(TDClientException.ErrorType.SOCKET_ERROR, e.getErrorType());
+                        assertTrue(e.getRootCause().get() instanceof ConnectException);
+                    }
+                    assertEquals(1, server.getRequestCount());
+                }
+                return null;
             }
-            else {
-                assertEquals(TDClientException.ErrorType.SOCKET_ERROR, e.getErrorType());
-                assertTrue(e.getRootCause().get() instanceof ConnectException);
+        });
+        t.submit(new Callable<Void>()
+        {
+            @Override
+            public Void call()
+                    throws Exception
+            {
+                // Close the server while sending the response
+                try {
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+                    logger.warn("Force closing a mock server");
+                    server.shutdown();
+                }
+                catch (Exception e) {
+                    logger.warn("failed to close server", e);
+                }
+                return null;
             }
-            assertEquals(1, accessCount.get());
+        });
+        t.shutdown();
+        if (!t.awaitTermination(5, TimeUnit.SECONDS)) {
+            fail("Gave up waiting MockServer termination");
         }
     }
 
@@ -297,23 +231,21 @@ public class TestServerFailures
     public void unknownResponseCode()
             throws Exception
     {
-        server.setHandler(new AbstractHandler()
+        server.setDispatcher(new Dispatcher()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                    throws IOException, ServletException
+            public MockResponse dispatch(RecordedRequest request)
+                    throws InterruptedException
             {
-                logger.debug("request: " + request);
-                if (request.getRequestURI().endsWith("server_status")) {
-                    response.setStatus(600); // return invalid response code
+                if (request.getPath().endsWith("server_status")) {
+                    return new MockResponse().setResponseCode(600); // return an invalid response code
                 }
                 else {
-                    response.setStatus(HttpStatus.NOT_ACCEPTABLE_406); // return invalid response code
+                    return new MockResponse().setResponseCode(HttpStatus.NOT_ACCEPTABLE_406); // return an invalid resonce code
                 }
-                baseRequest.setHandled(true);
             }
         });
-        startServer();
+        server.start(port);
 
         TDClient client = TDClient.newBuilder()
                 .setEndpoint("localhost")
@@ -342,29 +274,9 @@ public class TestServerFailures
     public void corruptedJsonResponse()
             throws Exception
     {
-        server.setHandler(new AbstractHandler()
-        {
-            AtomicInteger count = new AtomicInteger(0);
-
-            @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                    throws IOException, ServletException
-            {
-                logger.debug("request: " + request);
-                response.setStatus(HttpStatus.OK_200);
-                response.setContentType("plain/text");
-                if (count.get() == 0) {
-                    response.getOutputStream().print("{broken json}");
-                }
-                else {
-                    // invalid response
-                    response.getOutputStream().print("{\"databases\":1}");
-                }
-                baseRequest.setHandled(true);
-                count.incrementAndGet();
-            }
-        });
-        startServer();
+        server.enqueue(new MockResponse().setBody("{broken json}").setHeader(HttpHeaders.CONTENT_TYPE, "plain/text"));
+        server.enqueue(new MockResponse().setBody("{\"database\":1}").setHeader(HttpHeaders.CONTENT_TYPE, "plain/text"));
+        server.start(port);
 
         TDClient client = TDClient
                 .newBuilder()

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -1176,6 +1176,7 @@ public class TestTDClient
             throws Exception
     {
         // authenticate() method should retrieve apikey, and set it to the TDClient
+        // [NOTE] To pass this you need to add password config to ~/.td/td.conf
         Properties p = TDClientConfig.readTDConf();
         TDClient client = new TDClientBuilder(false).build(); // Set no API key
         String user = firstNonNull(p.getProperty("user"), System.getenv("TD_USER"));

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -61,7 +61,6 @@ import com.treasuredata.client.model.TDUserList;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.eclipse.jetty.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -1230,7 +1230,7 @@ public class TestTDClient
             throws Exception
     {
         TDUser user = client.getUser();
-        logger.info("user: {}", user);
+        logger.trace("user: {}", user);
     }
 
     @Test
@@ -1239,9 +1239,9 @@ public class TestTDClient
     {
         TDUserList userList = client.listUsers();
         for (TDUser user : userList.getUsers()) {
-            logger.info("user: {}", user);
+            logger.trace("user: {}", user);
         }
-        logger.info("{} user(s)", userList.getUsers().size());
+        logger.trace("{} user(s)", userList.getUsers().size());
     }
 
     @Test

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -107,6 +107,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import static com.treasuredata.client.TDClientConfig.ENV_TD_CLIENT_APIKEY;
+
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -432,9 +433,13 @@ public class TestTDClient
     {
         client.deleteTableIfExists(SAMPLE_DB, "sample_output");
         String poolName = "hadoop2";
-        String jobId = client.submit(TDJobRequest.newPrestoQuery("sample_datasets", "-- td-client-java test\nselect count(*) from nasdaq", null, poolName));
-        TDJobSummary tdJob = waitJobCompletion(jobId);
-        client.existsTable(SAMPLE_DB, "sample_output");
+        try {
+            String jobId = client.submit(TDJobRequest.newPrestoQuery("sample_datasets", "-- td-client-java test\nselect count(*) from nasdaq", null, poolName));
+            fail("should not reach here");
+        }
+        catch (TDClientHttpException e) {
+            assertEquals(400, e.getStatusCode());
+        }
     }
 
     @Test
@@ -1461,7 +1466,6 @@ public class TestTDClient
 
         assertThat(recordedRequest.getPath(), is("/v3/job/kill/4711"));
         assertThat(recordedRequest.getHeader("Authorization"), is("TD1 " + apikey));
-
     }
 
     @Test

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -298,10 +298,16 @@ public class TestTDClient
         assertTrue(jobsInAnIDRange.getJobs().size() > 0);
 
         // Check getters
-        Iterable<Method> getters = Iterables.filter(ImmutableList.copyOf(TDJob.class.getDeclaredMethods()), new Predicate<Method>()
+        Iterable<Method> getters = FluentIterable.from(TDJob.class.getDeclaredMethods()).filter(new Predicate<Method>()
         {
             @Override
             public boolean apply(Method input)
+            {
+                return test(input);
+            }
+
+            @Override
+            public boolean test(Method input)
             {
                 return input.getName().startsWith("get");
             }
@@ -996,6 +1002,12 @@ public class TestTDClient
                 @Override
                 public boolean apply(TDBulkImportSession input)
                 {
+                    return test(input);
+                }
+
+                @Override
+                public boolean test(TDBulkImportSession input)
+                {
                     return input.getName().equals(session);
                 }
             });
@@ -1128,6 +1140,12 @@ public class TestTDClient
             {
                 @Override
                 public boolean apply(TDTable input)
+                {
+                    return test(input);
+                }
+
+                @Override
+                public boolean test(TDTable input)
                 {
                     return input.getName().equals(bulkImportTable);
                 }

--- a/src/test/java/com/treasuredata/client/TestTDClientConfig.java
+++ b/src/test/java/com/treasuredata/client/TestTDClientConfig.java
@@ -39,7 +39,7 @@ import static com.treasuredata.client.TDClientConfig.Type.API_ENDPOINT;
 import static com.treasuredata.client.TDClientConfig.Type.API_PORT;
 import static com.treasuredata.client.TDClientConfig.Type.CONNECTION_POOL_SIZE;
 import static com.treasuredata.client.TDClientConfig.Type.CONNECT_TIMEOUT_MILLIS;
-import static com.treasuredata.client.TDClientConfig.Type.IDLE_TIMEOUT_MILLIS;
+import static com.treasuredata.client.TDClientConfig.Type.READ_TIMEOUT_MILLIS;
 import static com.treasuredata.client.TDClientConfig.Type.PASSOWRD;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_HOST;
 import static com.treasuredata.client.TDClientConfig.Type.PROXY_PASSWORD;
@@ -73,7 +73,7 @@ public class TestTDClientConfig
         p.put(API_PORT, 8981);
         p.put(USESSL, true);
         p.put(CONNECT_TIMEOUT_MILLIS, 2345);
-        p.put(IDLE_TIMEOUT_MILLIS, 3456);
+        p.put(READ_TIMEOUT_MILLIS, 3456);
         p.put(CONNECTION_POOL_SIZE, 234);
         p.put(RETRY_LIMIT, 11);
         p.put(RETRY_INITIAL_INTERVAL_MILLIS, 456);
@@ -93,7 +93,7 @@ public class TestTDClientConfig
         assertEquals(m.get(USESSL), config.useSSL);
         assertEquals(m.get(CONNECT_TIMEOUT_MILLIS), config.connectTimeoutMillis);
         assertEquals(m.get(CONNECTION_POOL_SIZE), config.connectionPoolSize);
-        assertEquals(m.get(IDLE_TIMEOUT_MILLIS), config.idleTimeoutMillis);
+        assertEquals(m.get(READ_TIMEOUT_MILLIS), config.readTimeoutMillis);
         assertEquals(m.get(RETRY_INITIAL_INTERVAL_MILLIS), config.retryInitialIntervalMillis);
         assertEquals(m.get(RETRY_MAX_INTERVAL_MILLIS), config.retryMaxIntervalMillis);
         assertEquals((double) m.get(RETRY_MULTIPLIER), config.retryMultiplier, 0.001);
@@ -122,7 +122,7 @@ public class TestTDClientConfig
         b.setUseSSL(Boolean.parseBoolean(m.get(USESSL).toString()));
         b.setConnectTimeoutMillis(Integer.parseInt(m.get(CONNECT_TIMEOUT_MILLIS).toString()));
         b.setConnectionPoolSize(Integer.parseInt(m.get(CONNECTION_POOL_SIZE).toString()));
-        b.setReadTimeoutMillis(Integer.parseInt(m.get(IDLE_TIMEOUT_MILLIS).toString()));
+        b.setReadTimeoutMillis(Integer.parseInt(m.get(READ_TIMEOUT_MILLIS).toString()));
         b.setRetryInitialIntervalMillis(Integer.parseInt(m.get(RETRY_INITIAL_INTERVAL_MILLIS).toString()));
         b.setRetryMaxIntervalMillis(Integer.parseInt(m.get(RETRY_MAX_INTERVAL_MILLIS).toString()));
         b.setRetryMultiplier(Double.parseDouble(m.get(RETRY_MULTIPLIER).toString()));

--- a/src/test/java/com/treasuredata/client/TestTDClientConfig.java
+++ b/src/test/java/com/treasuredata/client/TestTDClientConfig.java
@@ -122,7 +122,7 @@ public class TestTDClientConfig
         b.setUseSSL(Boolean.parseBoolean(m.get(USESSL).toString()));
         b.setConnectTimeoutMillis(Integer.parseInt(m.get(CONNECT_TIMEOUT_MILLIS).toString()));
         b.setConnectionPoolSize(Integer.parseInt(m.get(CONNECTION_POOL_SIZE).toString()));
-        b.setIdleTimeoutMillis(Integer.parseInt(m.get(IDLE_TIMEOUT_MILLIS).toString()));
+        b.setReadTimeoutMillis(Integer.parseInt(m.get(IDLE_TIMEOUT_MILLIS).toString()));
         b.setRetryInitialIntervalMillis(Integer.parseInt(m.get(RETRY_INITIAL_INTERVAL_MILLIS).toString()));
         b.setRetryMaxIntervalMillis(Integer.parseInt(m.get(RETRY_MAX_INTERVAL_MILLIS).toString()));
         b.setRetryMultiplier(Double.parseDouble(m.get(RETRY_MULTIPLIER).toString()));

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -271,26 +271,15 @@ public class TestTDHttpClient
         assertThat(requests, is(4));
     }
 
-    @Test(expected = TDClientProcessingException.class)
-    public void failWithMaxLength()
-            throws Exception
-    {
-        final TDApiRequest req = TDApiRequest.Builder.GET("/v3/system/server_status").build();
-        final byte[] body = new byte[3 * 1024 * 1024]; // jetty's default is 2 * 1024 * 1024
-        Arrays.fill(body, (byte) 100);
-
-        client.submitRequest(req, Optional.<String>absent(), new TestDefaultHandler(Optional.<Integer>absent(), body));
-    }
-
     @Test
-    public void successWithMaxLength()
+    public void readBodyAsBytes()
             throws Exception
     {
         final TDApiRequest req = TDApiRequest.Builder.GET("/v3/system/server_status").build();
-        final byte[] body = new byte[3 * 1024 * 1024]; // jetty's default is 2 * 1024 * 1024
+        final byte[] body = new byte[3 * 1024 * 1024];
         Arrays.fill(body, (byte) 100);
 
-        byte[] res = client.submitRequest(req, Optional.<String>absent(), new TestDefaultHandler(Optional.of(body.length), body));
+        byte[] res = client.submitRequest(req, Optional.<String>absent(), new TestDefaultHandler(body));
         assertThat(res, is(body));
     }
 
@@ -299,7 +288,7 @@ public class TestTDHttpClient
     {
         private final byte[] body;
 
-        public TestDefaultHandler(Optional<Integer> maxContent, byte[] body)
+        public TestDefaultHandler(byte[] body)
         {
             this.body = body;
         }
@@ -308,6 +297,7 @@ public class TestTDHttpClient
         public Response send(OkHttpClient httpClient, Request request)
                 throws IOException
         {
+            // Return a dummy response
             return new Response.Builder()
                     .request(request)
                     .code(200)

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -314,6 +314,8 @@ public class TestTDHttpClient
             return new Response.Builder()
                     .request(request)
                     .code(200)
+                    .message("")
+                    .protocol(Protocol.HTTP_1_1)
                     .header("Content-Length", String.valueOf(body.length))
                     .body(ResponseBody.create(MediaType.parse("plain/text"), body))
                     .build();

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -51,12 +51,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.exparity.hamcrest.date.DateMatchers.within;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  *
@@ -294,7 +291,7 @@ public class TestTDHttpClient
         Arrays.fill(body, (byte) 100);
 
         byte[] res = client.submitRequest(req, Optional.<String>absent(), new TestDefaultHandler(Optional.of(body.length), body));
-        assertEquals(body, res);
+        assertThat(res, is(body));
     }
 
     private static class TestDefaultHandler
@@ -383,9 +380,13 @@ public class TestTDHttpClient
     public void testParseRetryAfterHttpDate()
             throws Exception
     {
-        Response response = mock(Response.class);
-        Headers headers = Headers.of("Retry-After", "Fri, 31 Dec 1999 23:59:59 GMT");
-        when(response.headers()).thenReturn(headers);
+        Response response = new Response.Builder()
+                .request(new Request.Builder().url("https://api.treasuredata.com/v3/server_status").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("")
+                .headers(Headers.of("Retry-After", "Fri, 31 Dec 1999 23:59:59 GMT"))
+                .build();
 
         long now = System.currentTimeMillis();
         Date d = TDHttpClient.parseRetryAfter(now, response);
@@ -398,9 +399,13 @@ public class TestTDHttpClient
     public void testParseRetryAfterSeconds()
             throws Exception
     {
-        Response response = mock(Response.class);
-        Headers headers = Headers.of("Retry-After", "120");
-        when(response.headers()).thenReturn(headers);
+        Response response = new Response.Builder()
+                .request(new Request.Builder().url("https://api.treasuredata.com/v3/server_status").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("")
+                .headers(Headers.of("Retry-After", "120"))
+                .build();
 
         long now = System.currentTimeMillis();
 

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -48,6 +48,8 @@ import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.treasuredata.client.TDHttpRequestHandlers.stringContentHandler;
+
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.exparity.hamcrest.date.DateMatchers.within;
 import static org.hamcrest.Matchers.is;
@@ -88,7 +90,7 @@ public class TestTDHttpClient
     public void addHttpRequestHeader()
     {
         TDApiRequest req = TDApiRequest.Builder.GET("/v3/system/server_status").addHeader("TEST_HEADER", "hello td-client-java").build();
-        String resp = client.submitRequest(req, Optional.<String>absent(), new TDHttpClient.StringContentHandler());
+        String resp = client.submitRequest(req, Optional.<String>absent(), stringContentHandler);
     }
 
     @Test
@@ -96,7 +98,7 @@ public class TestTDHttpClient
     {
         try {
             TDApiRequest req = TDApiRequest.Builder.DELETE("/v3/dummy_endpoint").build();
-            String resp = client.submitRequest(req, Optional.<String>absent(), new TDHttpClient.StringContentHandler());
+            String resp = client.submitRequest(req, Optional.<String>absent(), stringContentHandler);
         }
         catch (TDClientHttpException e) {
             logger.warn("error", e);
@@ -122,7 +124,7 @@ public class TestTDHttpClient
         final byte[] body = "foobar".getBytes("UTF-8");
         final long retryAfterSeconds = 5;
 
-        byte[] result = client.submitRequest(req, Optional.<String>absent(), new TDHttpClient.DefaultHandler<byte[]>()
+        byte[] result = client.submitRequest(req, Optional.<String>absent(), new TDHttpRequestHandler<byte[]>()
         {
             @Override
             public Response send(OkHttpClient httpClient, Request request)
@@ -155,7 +157,6 @@ public class TestTDHttpClient
                 }
             }
 
-            @Override
             public byte[] onSuccess(Response response)
                     throws Exception
             {
@@ -284,7 +285,7 @@ public class TestTDHttpClient
     }
 
     private static class TestDefaultHandler
-            extends TDHttpClient.DefaultHandler<byte[]>
+            implements TDHttpRequestHandler<byte[]>
     {
         private final byte[] body;
 
@@ -323,7 +324,7 @@ public class TestTDHttpClient
         final TDApiRequest req = TDApiRequest.Builder.GET("/v3/system/server_status").build();
 
         try {
-            client.submitRequest(req, Optional.<String>absent(), new TDHttpClient.DefaultHandler<byte[]>()
+            client.submitRequest(req, Optional.<String>absent(), new TDHttpRequestHandler<byte[]>()
             {
                 @Override
                 public Response send(OkHttpClient httpClient, Request request)


### PR DESCRIPTION
- When td-client is used with jetty 9.4.4, it causes severe problems (especially when using Presto 0.187 + td-client at the same time). 
- Fixing various issues in #99 (jetty upgrade) seems difficult
- This PR also includes Guava, Jackson upgrades
- Targeting Java8 because Guava 21.0 or higher basically requires Java8.
