### PR TITLE
Let subclass of TDHttpClient call super to initialize from TDHttpClient

### DIFF
--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -129,6 +129,11 @@ public class TDHttpClient
         this.objectMapper = defaultObjectMapper;
     }
 
+    protected TDHttpClient(TDHttpClient reference)
+    {
+        this(reference.config, reference.httpClient, reference.objectMapper, reference.headers);
+    }
+
     private TDHttpClient(TDClientConfig config, OkHttpClient httpClient, ObjectMapper objectMapper, Multimap<String, String> headers)
     {
         this.config = config;


### PR DESCRIPTION
A subclass of TDHttpClient needs to override withHeaders method to
return an instance of the subclass. The new instance shares all private
fields excepting headers (config, httpClient, and objectMapper) with the
old instance. But because the fields are private, constructor of the
subclass can't call super with the private objects.

This change lets the subclass to overrie withHeaders method as
following:

    return new MyTDHttpClient(super.withHeaders(headers));