### PR TITLE
Add resource pool name in performing bulk import

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -701,9 +701,25 @@ public class TDClient
     }
 
     @Override
+    public void performBulkImportSession(String sessionName, Optional<String> poolName)
+    {
+        performBulkImportSession(sessionName, poolName, TDJob.Priority.NORMAL);
+    }
+
+    @Override
     public void performBulkImportSession(String sessionName, TDJob.Priority priority)
     {
-        doPost(buildUrl("/v3/bulk_import/perform", sessionName), ImmutableMap.of("priority", Integer.toString(priority.toInt())), Optional.<String>absent(), String.class);
+        performBulkImportSession(sessionName, Optional.absent(), priority);
+    }
+
+    @Override
+    public void performBulkImportSession(String sessionName, Optional<String> poolName, TDJob.Priority priority)
+    {
+        Optional<String> jsonBody = Optional.absent();
+        if (poolName.isPresent()) {
+            jsonBody = Optional.of(JSONObject.toJSONString(ImmutableMap.of("pool_name", poolName.get())));
+        }
+        doPost(buildUrl("/v3/bulk_import/perform", sessionName), ImmutableMap.of("priority", Integer.toString(priority.toInt())), jsonBody, String.class);
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -19,6 +19,7 @@
 package com.treasuredata.client;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.collect.Multimap;
 
 import com.treasuredata.client.model.TDBulkImportSession;
@@ -241,7 +242,11 @@ public interface TDClientApi<ClientImpl>
 
     void performBulkImportSession(String sessionName);
 
+    void performBulkImportSession(String sessionName, Optional<String> poolName);
+
     void performBulkImportSession(String sessionName, TDJob.Priority priority);
+
+    void performBulkImportSession(String sessionName, Optional<String> poolName, TDJob.Priority priority);
 
     void commitBulkImportSession(String sessionName);
 


### PR DESCRIPTION
Allow having the resource pool name parameter for performing bulk import, keep the backward compatibility.