### PR TITLE
Support result_export on TDClient

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -962,7 +962,7 @@ public class TDClient
     public String submitResultExportJob(TDExportResultJobRequest jobRequest)
     {
         Map<String, String> queryParam = new HashMap<>();
-        queryParam.put("result", jobRequest.getResult());
+        queryParam.put("result", jobRequest.getResultOutput());
 
         TDJobSubmitResult result = doPost(
                 buildUrl("/v3/job/result_export", jobRequest.getJobId()),

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -39,6 +39,7 @@ import com.treasuredata.client.model.TDColumn;
 import com.treasuredata.client.model.TDConnectionLookupResult;
 import com.treasuredata.client.model.TDDatabase;
 import com.treasuredata.client.model.TDExportJobRequest;
+import com.treasuredata.client.model.TDExportResultJobRequest;
 import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobList;
 import com.treasuredata.client.model.TDJobRequest;
@@ -955,5 +956,19 @@ public class TDClient
     public long lookupConnection(String name)
     {
         return doGet(buildUrl("/v3/connections/lookup?name=" + urlPathSegmentEscaper().escape(name)), TDConnectionLookupResult.class).getId();
+    }
+
+    @Override
+    public String submitResultExportJob(TDExportResultJobRequest jobRequest)
+    {
+        Map<String, String> queryParam = new HashMap<>();
+        queryParam.put("result", jobRequest.getResult());
+
+        TDJobSubmitResult result = doPost(
+                buildUrl("/v3/job/result_export", jobRequest.getJobId()),
+                queryParam,
+                TDJobSubmitResult.class);
+
+        return result.getJobId();
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -28,6 +28,7 @@ import com.treasuredata.client.model.TDBulkLoadSessionStartResult;
 import com.treasuredata.client.model.TDColumn;
 import com.treasuredata.client.model.TDDatabase;
 import com.treasuredata.client.model.TDExportJobRequest;
+import com.treasuredata.client.model.TDExportResultJobRequest;
 import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobList;
 import com.treasuredata.client.model.TDJobRequest;
@@ -363,6 +364,14 @@ public interface TDClientApi<ClientImpl>
      * @return job id
      */
     TDBulkLoadSessionStartResult startBulkLoadSession(String name, TDBulkLoadSessionStartRequest request);
+
+    /**
+     * Start a result_export job.
+     *
+     * @param jobRequest
+     * @return job id
+     */
+    String submitResultExportJob(TDExportResultJobRequest jobRequest);
 
     long lookupConnection(String name);
 }

--- a/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
@@ -1,0 +1,47 @@
+package com.treasuredata.client.model;
+
+import org.immutables.builder.Builder;
+import org.immutables.value.Value;
+
+@Value.Style(typeBuilder = "TDExportResultJobRequestBuilder")
+public class TDExportResultJobRequest
+{
+    private final String jobId;
+    private final String result;
+
+    private TDExportResultJobRequest(String jobId, String result)
+    {
+        this.jobId = jobId;
+        this.result = result;
+    }
+
+    public String getJobId()
+    {
+        return jobId;
+    }
+
+    public String getResult()
+    {
+        return result;
+    }
+
+    @Builder.Factory
+    static TDExportResultJobRequest of(String jobId, String result)
+    {
+        return new TDExportResultJobRequest(jobId, result);
+    }
+
+    public static TDExportResultJobRequestBuilder builder()
+    {
+        return new TDExportResultJobRequestBuilder();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TDExportResultJobRequest{" +
+                "jobId='" + jobId + '\'' +
+                ", result='" + result + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
@@ -7,12 +7,12 @@ import org.immutables.value.Value;
 public class TDExportResultJobRequest
 {
     private final String jobId;
-    private final String result;
+    private final String resultOutput;
 
-    private TDExportResultJobRequest(String jobId, String result)
+    private TDExportResultJobRequest(String jobId, String resultOutput)
     {
         this.jobId = jobId;
-        this.result = result;
+        this.resultOutput = resultOutput;
     }
 
     public String getJobId()
@@ -20,15 +20,15 @@ public class TDExportResultJobRequest
         return jobId;
     }
 
-    public String getResult()
+    public String getResultOutput()
     {
-        return result;
+        return resultOutput;
     }
 
     @Builder.Factory
-    static TDExportResultJobRequest of(String jobId, String result)
+    static TDExportResultJobRequest of(String jobId, String resultOutput)
     {
-        return new TDExportResultJobRequest(jobId, result);
+        return new TDExportResultJobRequest(jobId, resultOutput);
     }
 
     public static TDExportResultJobRequestBuilder builder()
@@ -41,7 +41,7 @@ public class TDExportResultJobRequest
     {
         return "TDExportResultJobRequest{" +
                 "jobId='" + jobId + '\'' +
-                ", result='" + result + '\'' +
+                ", resultOutput='" + resultOutput + '\'' +
                 '}';
     }
 }

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -43,6 +43,7 @@ import com.treasuredata.client.model.TDColumnType;
 import com.treasuredata.client.model.TDDatabase;
 import com.treasuredata.client.model.TDExportFileFormatType;
 import com.treasuredata.client.model.TDExportJobRequest;
+import com.treasuredata.client.model.TDExportResultJobRequest;
 import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobList;
 import com.treasuredata.client.model.TDJobRequest;
@@ -1554,6 +1555,21 @@ public class TestTDClient
         assertThat(request2.getHeaders().toMultimap().get("k2"), containsInAnyOrder("v2"));
         assertThat(request2.getHeaders().toMultimap().get("k3"), containsInAnyOrder("v3"));
         assertThat(request2.getHeaders().toMultimap().get("k4"), containsInAnyOrder("v4"));
+    }
+
+    @Test
+    public void submitResultExportJob()
+    {
+        client = mockClient();
+        server.enqueue(new MockResponse().setBody("{\"job_id\":\"17\"}"));
+
+        TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
+                .jobId("17")
+                .result("td://api_key@/sample_database/sample_output_table")
+                .build();
+
+        String jobId = client.submitResultExportJob(jobRequest);
+        assertEquals("17", jobId);
     }
 
     private static String apikey()

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -1565,7 +1565,7 @@ public class TestTDClient
 
         TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
                 .jobId("17")
-                .result("td://api_key@/sample_database/sample_output_table")
+                .resultOutput("td://api_key@/sample_database/sample_output_table")
                 .build();
 
         String jobId = client.submitResultExportJob(jobRequest);


### PR DESCRIPTION
# What will this PR change ? 
- This PR enables to access result_export endpoint (`POST /v3/job/result_export/:id`).
- This endpoint access is already supported in [td-client-ruby](https://github.com/treasure-data/td-client-ruby/blob/614a463551f9ac91fb13f1c845f21720a5f7569c/lib/td/client/api/export.rb#L25-L36)

# Example of use

```java
TDClient client = TDClient
        .newBuilder()
        .setApiKey("api_key")
        .build();

TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
        .jobId("12345")
        .result("td://@/my_db/my_table")
        .build();

String jobId = client.submitResultExportJob(jobRequest);
System.out.println(jobId); // => 12346
```