### PR TITLE
Add new parameters for TDExportResultJobRequest

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -962,7 +962,16 @@ public class TDClient
     public String submitResultExportJob(TDExportResultJobRequest jobRequest)
     {
         Map<String, String> queryParam = new HashMap<>();
-        queryParam.put("result", jobRequest.getResultOutput());
+        if (!jobRequest.getResultConnectionId().isEmpty() && !jobRequest.getResultConnectionSettings().isEmpty()) {
+            queryParam.put("result_connection_id", jobRequest.getResultConnectionId());
+            queryParam.put("result_connection_settings", jobRequest.getResultConnectionSettings());
+        }
+        else if (!jobRequest.getResultOutput().isEmpty()) {
+            queryParam.put("result", jobRequest.getResultOutput());
+        }
+        else {
+            throw new IllegalStateException("Either resultOutput or a pair of resultConnectionId and resultConnectionSettings is required");
+        }
 
         TDJobSubmitResult result = doPost(
                 buildUrl("/v3/job/result_export", jobRequest.getJobId()),

--- a/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
@@ -1,5 +1,6 @@
 package com.treasuredata.client.model;
 
+import com.google.common.base.Optional;
 import org.immutables.builder.Builder;
 import org.immutables.value.Value;
 
@@ -8,11 +9,15 @@ public class TDExportResultJobRequest
 {
     private final String jobId;
     private final String resultOutput;
+    private final String resultConnectionId;
+    private final String resultConnectionSettings;
 
-    private TDExportResultJobRequest(String jobId, String resultOutput)
+    private TDExportResultJobRequest(String jobId, String resultOutput, String reseultConnectionId, String resultConnectionSettings)
     {
         this.jobId = jobId;
         this.resultOutput = resultOutput;
+        this.resultConnectionId = reseultConnectionId;
+        this.resultConnectionSettings = resultConnectionSettings;
     }
 
     public String getJobId()
@@ -25,10 +30,20 @@ public class TDExportResultJobRequest
         return resultOutput;
     }
 
+    public String getResultConnectionId() { return resultConnectionId; }
+
+    public String getResultConnectionSettings() { return resultConnectionSettings; }
+
     @Builder.Factory
-    static TDExportResultJobRequest of(String jobId, String resultOutput)
+    static TDExportResultJobRequest of(String jobId,
+            Optional<String> resultOutput,
+            Optional<String> resultConnectionId,
+            Optional<String> resultConnectionSettings)
     {
-        return new TDExportResultJobRequest(jobId, resultOutput);
+        return new TDExportResultJobRequest(jobId,
+                resultOutput.or(""),
+                resultConnectionId.or(""),
+                resultConnectionSettings.or(""));
     }
 
     public static TDExportResultJobRequestBuilder builder()
@@ -42,6 +57,8 @@ public class TDExportResultJobRequest
         return "TDExportResultJobRequest{" +
                 "jobId='" + jobId + '\'' +
                 ", resultOutput='" + resultOutput + '\'' +
+                ", resultConnectionId='" + resultConnectionId + '\'' +
+                ", resultConnectionSettings='" + resultConnectionSettings + '\'' +
                 '}';
     }
 }

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -1558,7 +1558,7 @@ public class TestTDClient
     }
 
     @Test
-    public void submitResultExportJob()
+    public void submitResultExportJobWithResultOutput()
     {
         client = mockClient();
         server.enqueue(new MockResponse().setBody("{\"job_id\":\"17\"}"));
@@ -1570,6 +1570,38 @@ public class TestTDClient
 
         String jobId = client.submitResultExportJob(jobRequest);
         assertEquals("17", jobId);
+    }
+
+    @Test
+    public void submitResultExportJobWithConnectionId()
+    {
+        client = mockClient();
+        server.enqueue(new MockResponse().setBody("{\"job_id\":\"17\"}"));
+
+        TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
+                .jobId("17")
+                .resultConnectionId("3822")
+                .resultConnectionSettings(
+                        "{\"api_key\":\"api_key\"," +
+                                "\"user_database_name\":\"sample_database\"," +
+                                "\"user_table_name\":\"sample_output_table\"}")
+                .build();
+
+        String jobId = client.submitResultExportJob(jobRequest);
+        assertEquals("17", jobId);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void submitResultExportJobWithOnlyJobId()
+    {
+        client = mockClient();
+        server.enqueue(new MockResponse().setBody("{\"job_id\":\"17\"}"));
+
+        TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
+                .jobId("17")
+                .build();
+
+        client.submitResultExportJob(jobRequest);
     }
 
     private static String apikey()


### PR DESCRIPTION
# What is this PR ?
- This PR add new parameters `resultConnectionId` (ID String) and `resultConnectionSettings` (JSON String)
- These parameters are used to specify the connector where the job result is exported to, instead of `resultOutput`(legacy url)

# Usage
```java
TDClient client = TDClient
        .newBuilder()
        .setApiKey("apikey")
        .build();

TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
        .jobId("17")
        .resultConnectionId("3822")
        .resultConnectionSettings(
                "{\"api_key\":\"api_key\"," +
                 "\"user_database_name\":\"sample_database\"," +
                 "\"user_table_name\":\"sample_output_table\"}")
        .build();
client.submitResultExportJob(jobRequest)
```