### PR TITLE
Upgrade jackson for addressing the security issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,9 @@ jobs:
       - checkout
       - run:
           name: Test
-          command: |
-            mvn test findbugs:check
+          command: mvn test
+      - run:
+          name: Find Bugs
+          command: mvn findbugs:check
       - store_artifacts:
             path: /tmp/td-client-java/target/site

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /tmp/td-client-java
     docker:
-      - image: circleci/openjdk:8-jdk-browsers-legacy
+      - image: circleci/openjdk:8-jdk-node-browsers
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /tmp/td-client-java
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: circleci/openjdk:8-jdk-browsers-legacy
     steps:
       - checkout
       - run:

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>2.22.1</version>
         <configuration>
           <argLine>${jacocoSurefireArgLine}</argLine>
           <!-- by default, test cases are included. -->
@@ -470,7 +470,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.2.201409121644</version>
+        <version>0.8.2</version>
         <executions>
           <execution>
             <id>pre-unit-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.1</version>
         <configuration>
+	  <!-- This config was necessary to run tests on Circle CI -->
           <forkCount>0</forkCount>
           <argLine>${jacocoSurefireArgLine}</argLine>
           <!-- by default, test cases are included. -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <project.build.jvmsize>512m</project.build.jvmsize>
-    <project.test.fork-mode>once</project.test.fork-mode>
 
     <project.check.skip-all>false</project.check.skip-all>
     <project.check.skip-dependency>${project.check.skip-all}</project.check.skip-dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.1</version>
         <configuration>
+          <forkCount>0</forkCount>
           <argLine>${jacocoSurefireArgLine}</argLine>
           <!-- by default, test cases are included. -->
           <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>td-client</artifactId>
   <name>Treasure Data Client for Java</name>
   <description>Treasure Data Client for Java.</description>
-  <version>0.8.6</version>
+  <version>0.8.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/treasure-data/td-client-java</url>
 
@@ -134,31 +134,31 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.8.1</version>
+      <version>2.8.11</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.8.1</version>
+      <version>2.8.11.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.8.1</version>
+      <version>2.8.11</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.8.1</version>
+      <version>2.8.11</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-json-org</artifactId>
-      <version>2.8.1</version>
+      <version>2.8.11</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Jackson 2.8 has an security issue. We need to upgrade it to 2.8.11(.1) https://github.com/treasure-data/td-client-java/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open

And also fixed the CircleCI issue by disabling JVM fork. 