### PR TITLE
Return optional value for tableDistribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.5</version>
         <configuration>
           <skip>${project.check.skip-findbugs}</skip>
           <jvmArgs>-Xmx${project.build.jvmsize}</jvmArgs>

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -983,8 +983,14 @@ public class TDClient
     }
 
     @Override
-    public TDTableDistribution tableDistribution(String databaseName, String tableName)
+    public Optional<TDTableDistribution> tableDistribution(String databaseName, String tableName)
     {
-        return doGet(buildUrl(String.format("/v3/table/distribution/%s/%s", databaseName, tableName)), TDTableDistribution.class);
+        try {
+            TDTableDistribution distribution = doGet(buildUrl(String.format("/v3/table/distribution/%s/%s", databaseName, tableName)), TDTableDistribution.class);
+            return Optional.of(distribution);
+        }
+        catch(TDClientHttpNotFoundException e) {
+            return Optional.absent();
+        }
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -989,7 +989,7 @@ public class TDClient
             TDTableDistribution distribution = doGet(buildUrl(String.format("/v3/table/distribution/%s/%s", databaseName, tableName)), TDTableDistribution.class);
             return Optional.of(distribution);
         }
-        catch(TDClientHttpNotFoundException e) {
+        catch (TDClientHttpNotFoundException e) {
             return Optional.absent();
         }
     }

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -376,5 +376,5 @@ public interface TDClientApi<ClientImpl>
 
     long lookupConnection(String name);
 
-    TDTableDistribution tableDistribution(String databaseName, String tableName);
+    Optional<TDTableDistribution> tableDistribution(String databaseName, String tableName);
 }

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -243,7 +243,7 @@ public class TDClientConfig
         Properties p = new Properties();
         File file = new File(System.getProperty("user.home", "./"), String.format(".td/td.conf"));
         if (!file.exists()) {
-            logger.debug(String.format("config file %s is not found", file));
+            logger.warn(String.format("config file %s is not found", file));
             return p;
         }
         return readTDConf(file);

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -243,7 +243,7 @@ public class TDClientConfig
         Properties p = new Properties();
         File file = new File(System.getProperty("user.home", "./"), String.format(".td/td.conf"));
         if (!file.exists()) {
-            logger.warn(String.format("config file %s is not found", file));
+            logger.debug(String.format("config file %s is not found", file));
             return p;
         }
         return readTDConf(file);

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -404,11 +404,8 @@ public class TDHttpClient
                 }
             }
             catch (Exception e) {
-                if (e instanceof TDClientHttpConflictException) {
-                    // Suppress stack trace because 409 frequently happens when checking the presence of databases and tables
-                    logger.warn(String.format("API request to %s failed: %s, cause: %s", context.apiRequest.getPath(), e.getClass(), e.getCause() == null ? e.getMessage() : e.getCause().getClass()));
-                }
-                else {
+                if (!(e instanceof TDClientHttpException)) {
+                    // TDClientHttpException is already handled in TDRequestErrorHandler, so we need to show warning for the other types of error messages
                     logger.warn(String.format("API request to %s failed: %s, cause: %s", context.apiRequest.getPath(), e.getClass(), e.getCause() == null ? e.getMessage() : e.getCause().getClass()), e);
                 }
                 // This may throw TDClientException if the error is not recoverable

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -404,8 +404,8 @@ public class TDHttpClient
                 }
             }
             catch (Exception e) {
-                if (!(e instanceof TDClientHttpException)) {
-                    // TDClientHttpException is already handled in TDRequestErrorHandler, so we need to show warning for the other types of error messages
+                // TDClientHttpException is already handled in TDRequestErrorHandler, so we need to show warning for the other types of error messages
+                if (!TDClientHttpException.class.isAssignableFrom(e.getClass())) {
                     logger.warn(String.format("API request to %s failed: %s, cause: %s", context.apiRequest.getPath(), e.getClass(), e.getCause() == null ? e.getMessage() : e.getCause().getClass()), e);
                 }
                 // This may throw TDClientException if the error is not recoverable

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -70,10 +70,8 @@ public class TDRequestErrorHandler
         int code = e.getStatusCode();
         switch (code) {
             case HttpStatus.NOT_FOUND_404:
-                if (responseContext.apiRequest.getPath().startsWith("/v3/table/distribution")) {
-                    // Table distribution data will not be found for non-UDP tables.
-                    showWarning = false;
-                }
+                // Not found (e.g., database, table, table distribution data might be missing)
+                showWarning = false;
                 break;
             case HttpStatus.CONFLICT_409:
                 // Suppress stack trace because 409 frequently happens when checking the presence of databases and tables.

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -63,12 +63,13 @@ public class TDRequestErrorHandler
     /**
      * Show or suppress warning messages for TDClientHttpException
      */
-    private static TDClientHttpException clientError(TDClientHttpException e, ResponseContext responseContext) {
+    private static TDClientHttpException clientError(TDClientHttpException e, ResponseContext responseContext)
+    {
         boolean showWarning = true;
         boolean showStackTrace = true;
-        switch(e.getStatusCode()) {
+        switch (e.getStatusCode()) {
             case HttpStatus.NOT_FOUND_404:
-                if(responseContext.apiRequest.getPath().startsWith("/v3/table/distribution")) {
+                if (responseContext.apiRequest.getPath().startsWith("/v3/table/distribution")) {
                     // Table distribution data will not be found for non-UDP tables.
                     showWarning = false;
                 }
@@ -78,8 +79,8 @@ public class TDRequestErrorHandler
                 showStackTrace = false;
                 break;
         }
-        if(showWarning) {
-            if(showStackTrace) {
+        if (showWarning) {
+            if (showStackTrace) {
                 logger.warn(String.format("API request to %s failed: %s, cause: %s", responseContext.apiRequest.getPath(), e.getClass(), e.getCause() == null ? e.getMessage() : e.getCause().getClass()), e);
             }
             else {

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -60,6 +60,35 @@ public class TDRequestErrorHandler
         }
     };
 
+    /**
+     * Show or suppress warning messages for TDClientHttpException
+     */
+    private static TDClientHttpException clientError(TDClientHttpException e, ResponseContext responseContext) {
+        boolean showWarning = true;
+        boolean showStackTrace = true;
+        switch(e.getStatusCode()) {
+            case HttpStatus.NOT_FOUND_404:
+                if(responseContext.apiRequest.getPath().startsWith("/v3/table/distribution")) {
+                    // Table distribution data will not be found for non-UDP tables.
+                    showWarning = false;
+                }
+                break;
+            case HttpStatus.CONFLICT_409:
+                // Suppress stack trace because 409 frequently happens when checking the presence of databases and tables.
+                showStackTrace = false;
+                break;
+        }
+        if(showWarning) {
+            if(showStackTrace) {
+                logger.warn(String.format("API request to %s failed: %s, cause: %s", responseContext.apiRequest.getPath(), e.getClass(), e.getCause() == null ? e.getMessage() : e.getCause().getClass()), e);
+            }
+            else {
+                logger.warn(String.format("API request to %s failed: %s, cause: %s", responseContext.apiRequest.getPath(), e.getClass(), e.getCause() == null ? e.getMessage() : e.getCause().getClass()));
+            }
+        }
+        return e;
+    }
+
     public static TDClientException defaultHttpResponseErrorResolver(ResponseContext responseContext)
             throws TDClientException
     {
@@ -76,30 +105,30 @@ public class TDRequestErrorHandler
             switch (code) {
                 // Soft 4xx errors. These we retry.
                 case TOO_MANY_REQUESTS_429:
-                    return new TDClientHttpTooManyRequestsException(errorMessage, retryAfter);
+                    return clientError(new TDClientHttpTooManyRequestsException(errorMessage, retryAfter), responseContext);
                 // Hard 4xx error. We do not retry the execution on this type of error
                 case HttpStatus.UNAUTHORIZED_401:
-                    throw new TDClientHttpUnauthorizedException(errorMessage);
+                    throw clientError(new TDClientHttpUnauthorizedException(errorMessage), responseContext);
                 case HttpStatus.NOT_FOUND_404:
-                    throw new TDClientHttpNotFoundException(errorMessage);
+                    throw clientError(new TDClientHttpNotFoundException(errorMessage), responseContext);
                 case HttpStatus.CONFLICT_409:
                     String conflictsWith = errorResponse.isPresent() ? parseConflictsWith(errorResponse.get()) : null;
-                    throw new TDClientHttpConflictException(errorMessage, conflictsWith);
+                    throw clientError(new TDClientHttpConflictException(errorMessage, conflictsWith), responseContext);
                 case HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407:
-                    throw new TDClientHttpException(PROXY_AUTHENTICATION_FAILURE, errorMessage, code, retryAfter);
+                    throw clientError(new TDClientHttpException(PROXY_AUTHENTICATION_FAILURE, errorMessage, code, retryAfter), responseContext);
                 case HttpStatus.UNPROCESSABLE_ENTITY_422:
-                    throw new TDClientHttpException(INVALID_INPUT, errorMessage, code, retryAfter);
+                    throw clientError(new TDClientHttpException(INVALID_INPUT, errorMessage, code, retryAfter), responseContext);
                 default:
-                    throw new TDClientHttpException(CLIENT_ERROR, errorMessage, code, retryAfter);
+                    throw clientError(new TDClientHttpException(CLIENT_ERROR, errorMessage, code, retryAfter), responseContext);
             }
         }
         logger.warn(errorMessage);
         if (HttpStatus.isServerError(code)) {
             // Just returns exception info for 5xx errors
-            return new TDClientHttpException(SERVER_ERROR, errorMessage, code, retryAfter);
+            return clientError(new TDClientHttpException(SERVER_ERROR, errorMessage, code, retryAfter), responseContext);
         }
         else {
-            throw new TDClientHttpException(UNEXPECTED_RESPONSE_CODE, errorMessage, code, retryAfter);
+            throw clientError(new TDClientHttpException(UNEXPECTED_RESPONSE_CODE, errorMessage, code, retryAfter), responseContext);
         }
     }
 

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -1612,13 +1612,22 @@ public class TestTDClient
         client = mockClient();
         server.enqueue(new MockResponse().setBody("{\"user_table_id\":123,\"bucket_count\":512,\"partition_function\":\"hash\",\"columns\":[{\"key\":\"col1\",\"type\":\"int\",\"name\":\"col1\"},{\"key\":\"col2\",\"type\":\"int\",\"name\":\"col2\"}]}"));
 
-        TDTableDistribution distribution = client.tableDistribution("sample_datasets", "www_access");
+        Optional<TDTableDistribution> distributionOpt = client.tableDistribution("sample_datasets", "www_access");
+        assertTrue(distributionOpt.isPresent());
+        TDTableDistribution distribution = distributionOpt.get();
         assertEquals(123, distribution.getUserTableId());
         assertEquals(512, distribution.getBucketCount());
         assertEquals("hash", distribution.getPartitionFunction());
         assertEquals(2, distribution.getColumns().size());
         assertEquals("col1", distribution.getColumns().get(0).getName());
         assertEquals("col2", distribution.getColumns().get(1).getName());
+    }
+
+    @Test
+    public void testMissingTableDistribution()
+    {
+        Optional<TDTableDistribution> distributionOpt = client.tableDistribution("sample_datasets", "www_access");
+        assertFalse(distributionOpt.isPresent());
     }
 
     private static String apikey()


### PR DESCRIPTION
- It's normal that table distribution data can be missing, so it should return Optional.
- Suppress 404 (not found) warning message, because it can frequently happen.