### PR TITLE
Introduce engine version in Hive, Presto

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -894,6 +894,7 @@ public class TDClient
     public TDSavedQuery saveQuery(TDSaveQueryRequest request)
     {
         String json = toJson(request);
+        logger.debug("saveQuery request:" + json);
         TDSavedQuery result =
                 doPost(
                         buildUrl("/v3/schedule/create", request.getName()),
@@ -907,6 +908,7 @@ public class TDClient
     public TDSavedQuery updateSavedQuery(String name, TDSavedQueryUpdateRequest request)
     {
         String json = request.toJson();
+        logger.debug("updateSaveQuery request:" + json);
         TDSavedQuery result =
                 doPost(
                         buildUrl("/v3/schedule/update", name),

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -612,6 +612,10 @@ public class TDClient
             queryParam.put("result_connection_settings", jobRequest.getResultConnectionSettings().get());
         }
 
+        if (jobRequest.getEngineVersion().isPresent()) {
+            queryParam.put("engine_version", jobRequest.getEngineVersion().get().getEngineVersion());
+        }
+
         if (logger.isDebugEnabled()) {
             logger.debug("submit job: " + jobRequest);
         }

--- a/src/main/java/com/treasuredata/client/model/TDJob.java
+++ b/src/main/java/com/treasuredata/client/model/TDJob.java
@@ -121,11 +121,6 @@ public class TDJob
             this.engineVersion = engineVersion;
         }
 
-        public static final EngineVersion EXPERIMENTAL = new EngineVersion("experimental");
-        public static final EngineVersion STABLE = new EngineVersion("stable");
-        public static final EngineVersion LEGACY = new EngineVersion("legacy");
-        public static final EngineVersion CURRENT = new EngineVersion("current");
-
         @JsonValue
         public String getEngineVersion()
         {
@@ -140,18 +135,7 @@ public class TDJob
 
         public static EngineVersion fromString(String engineVersion)
         {
-            switch (engineVersion) {
-                case "stable":
-                    return STABLE;
-                case "experimental":
-                    return EXPERIMENTAL;
-                case "legacy":
-                    return LEGACY;
-                case "current":
-                    return CURRENT;
-                default:
-                    return new EngineVersion(engineVersion);
-            }
+            return new EngineVersion(engineVersion);
         }
     }
 

--- a/src/main/java/com/treasuredata/client/model/TDJob.java
+++ b/src/main/java/com/treasuredata/client/model/TDJob.java
@@ -108,6 +108,53 @@ public class TDJob
         }
     }
 
+    /**
+     * Engine version for hive, presto
+     * To accept specific version number like 'Hive TD 2018.01', Implement as not enum but class
+     */
+    public static class EngineVersion
+    {
+        private final String engineVersion;
+
+        private EngineVersion(String engineVersion)
+        {
+            this.engineVersion = engineVersion;
+        }
+
+        public static final EngineVersion EXPERIMENTAL = new EngineVersion("experimental");
+        public static final EngineVersion STABLE = new EngineVersion("stable");
+        public static final EngineVersion LEGACY = new EngineVersion("legacy");
+        public static final EngineVersion CURRENT = new EngineVersion("current");
+
+        @JsonValue
+        public String getEngineVersion()
+        {
+            return engineVersion;
+        }
+
+        @Override
+        public String toString()
+        {
+            return engineVersion;
+        }
+
+        public static EngineVersion fromString(String engineVersion)
+        {
+            switch (engineVersion) {
+                case "stable":
+                    return STABLE;
+                case "experimental":
+                    return EXPERIMENTAL;
+                case "legacy":
+                    return LEGACY;
+                case "current":
+                    return CURRENT;
+                default:
+                    return new EngineVersion(engineVersion);
+            }
+        }
+    }
+
     private static class Debug
     {
         private final Optional<String> cmdout;
@@ -157,6 +204,7 @@ public class TDJob
     private final long resultSize;
     private final Optional<Debug> debug;
     private final long numRecords;
+    private final Optional<EngineVersion> engineVersion;
 
     @JsonCreator
     static TDJob createTDJobV3(
@@ -176,9 +224,10 @@ public class TDJob
             @JsonProperty("duration") long duration,
             @JsonProperty("result_size") long resultSize,
             @JsonProperty("debug") Optional<Debug> debug,
-            @JsonProperty("num_records") long numRecords)
+            @JsonProperty("num_records") long numRecords,
+            @JsonProperty("engine_version") Optional<EngineVersion> engineVersion)
     {
-        return new TDJob(jobId, status, type, query.getQuery(), createdAt, startAt, updatedAt, endAt, resultSchema, database, result, url, userName, duration, resultSize, debug, numRecords);
+        return new TDJob(jobId, status, type, query.getQuery(), createdAt, startAt, updatedAt, endAt, resultSchema, database, result, url, userName, duration, resultSize, debug, numRecords, engineVersion);
     }
 
     public TDJob(String jobId,
@@ -197,7 +246,8 @@ public class TDJob
             long duration,
             long resultSize,
             Optional<Debug> debug,
-            long numRecords
+            long numRecords,
+            Optional<EngineVersion> engineVersion
     )
     {
         this.jobId = jobId;
@@ -217,6 +267,7 @@ public class TDJob
         this.resultSize = resultSize;
         this.debug = debug;
         this.numRecords = numRecords;
+        this.engineVersion = engineVersion;
     }
 
     public String getJobId()
@@ -299,6 +350,11 @@ public class TDJob
         return numRecords;
     }
 
+    public Optional<EngineVersion> getEngineVersion()
+    {
+        return engineVersion;
+    }
+
     /**
      * A short cut for reading cmdout message
      *
@@ -354,6 +410,7 @@ public class TDJob
                 ", resultSize=" + resultSize +
                 ", debug=" + debug +
                 ", numRecords=" + numRecords +
+                ", engineVersion=" + engineVersion +
                 '}';
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequest.java
@@ -39,6 +39,7 @@ public class TDJobRequest
     private final Optional<String> domainKey;
     private final Optional<Long> resultConnectionId;
     private final Optional<String> resultConnectionSettings;
+    private final Optional<TDJob.EngineVersion> engineVersion;
 
     @Deprecated
     public TDJobRequest(String database, TDJob.Type type, String query, TDJob.Priority priority, Optional<String> resultOutput, Optional<Integer> retryLimit, Optional<String> poolName, Optional<String> table, Optional<ObjectNode> config)
@@ -56,6 +57,7 @@ public class TDJobRequest
         this.domainKey = Optional.absent();
         this.resultConnectionId = Optional.absent();
         this.resultConnectionSettings = Optional.absent();
+        this.engineVersion = Optional.absent();
     }
 
     private TDJobRequest(TDJobRequestBuilder builder)
@@ -73,6 +75,8 @@ public class TDJobRequest
         this.domainKey = builder.getDomainKey();
         this.resultConnectionId = builder.getResultConnectionId();
         this.resultConnectionSettings = builder.getResultConnectionSettings();
+        this.engineVersion = builder.getEngineVersion();
+
     }
 
     public static TDJobRequest newPrestoQuery(String database, String query)
@@ -241,6 +245,11 @@ public class TDJobRequest
         return resultConnectionSettings;
     }
 
+    public Optional<TDJob.EngineVersion> getEngineVersion()
+    {
+        return engineVersion;
+    }
+
     static TDJobRequest of(TDJobRequestBuilder builder)
     {
         return new TDJobRequest(builder);
@@ -263,6 +272,7 @@ public class TDJobRequest
                 ", domainKey=" + domainKey +
                 ", resultConnectionId=" + resultConnectionId +
                 ", resultConnectionSettings=" + resultConnectionSettings +
+                ", engineVersion=" + engineVersion +
                 '}';
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
@@ -36,6 +36,7 @@ public class TDJobRequestBuilder
     private Optional<String> domainKey = Optional.absent();
     private Optional<Long> resultConnectionId = Optional.absent();
     private Optional<String> resultConnectionSettings = Optional.absent();
+    private Optional<TDJob.EngineVersion> engineVersion = Optional.absent();
 
     public TDJobRequestBuilder setResultOutput(String result)
     {
@@ -210,6 +211,23 @@ public class TDJobRequestBuilder
     public TDJobRequestBuilder setResultConnectionSettings(String resultConnectionSettings)
     {
         return setResultConnectionSettings(Optional.fromNullable(resultConnectionSettings));
+    }
+
+    public TDJobRequestBuilder setEngineVersion(String engineVersion)
+    {
+        this.engineVersion = Optional.fromNullable(TDJob.EngineVersion.fromString(engineVersion));
+        return this;
+    }
+
+    public TDJobRequestBuilder setEngineVersion(TDJob.EngineVersion engineVersion)
+    {
+        this.engineVersion = Optional.fromNullable(engineVersion);
+        return this;
+    }
+
+    public Optional<TDJob.EngineVersion> getEngineVersion()
+    {
+        return engineVersion;
     }
 
     public TDJobRequest createTDJobRequest()

--- a/src/main/java/com/treasuredata/client/model/TDSaveQueryRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDSaveQueryRequest.java
@@ -18,6 +18,7 @@
  */
 package com.treasuredata.client.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -35,6 +36,7 @@ public class TDSaveQueryRequest
     private final int priority;
     private final int retryLimit;
     private final String result;
+    private final TDJob.EngineVersion engineVersion;
 
     public TDSaveQueryRequest(
             @JsonProperty("name") String name,
@@ -46,7 +48,8 @@ public class TDSaveQueryRequest
             @JsonProperty("database") String database,
             @JsonProperty("priority") int priority,
             @JsonProperty("retry_limit") int retryLimit,
-            @JsonProperty("result") String result)
+            @JsonProperty("result") String result,
+            @JsonProperty("engine_version") @JsonInclude(JsonInclude.Include.NON_NULL) TDJob.EngineVersion engineVersion)
     {
         this.name = name;
         this.cron = cron;
@@ -58,6 +61,7 @@ public class TDSaveQueryRequest
         this.priority = priority;
         this.retryLimit = retryLimit;
         this.result = result;
+        this.engineVersion = engineVersion;
     }
 
     public String getName()
@@ -109,5 +113,12 @@ public class TDSaveQueryRequest
     public String getResult()
     {
         return result;
+    }
+
+    @JsonProperty("engine_version")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public TDJob.EngineVersion getEngineVersion()
+    {
+        return engineVersion;
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDSavedQuery.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQuery.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -88,7 +87,7 @@ public class TDSavedQuery
             @JsonProperty("retry_limit") int retryLimit,
             @JsonProperty("result") String result,
             @JsonProperty("next_time") String nextTime,
-            @JsonProperty("engine_version") @JsonInclude(JsonInclude.Include.NON_NULL) TDJob.EngineVersion engineVersion
+            @JsonProperty("engine_version") TDJob.EngineVersion engineVersion
             )
     {
         this.id = id;

--- a/src/main/java/com/treasuredata/client/model/TDSavedQuery.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQuery.java
@@ -18,6 +18,7 @@
  */
 package com.treasuredata.client.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -54,6 +55,7 @@ public class TDSavedQuery
         b.setPriority(priority);
         b.setRetryLimit(retryLimit);
         b.setResult(result);
+        b.setEngineVersion(engineVersion);
         return b;
     }
 
@@ -70,6 +72,7 @@ public class TDSavedQuery
     private final int retryLimit;
     private final String result;
     private final String nextTime;
+    private final TDJob.EngineVersion engineVersion;
 
     public TDSavedQuery(
             @JsonProperty("id") String id,
@@ -84,7 +87,9 @@ public class TDSavedQuery
             @JsonProperty("priority") int priority,
             @JsonProperty("retry_limit") int retryLimit,
             @JsonProperty("result") String result,
-            @JsonProperty("next_time") String nextTime)
+            @JsonProperty("next_time") String nextTime,
+            @JsonProperty("engine_version") @JsonInclude(JsonInclude.Include.NON_NULL) TDJob.EngineVersion engineVersion
+            )
     {
         this.id = id;
         this.name = name;
@@ -99,6 +104,7 @@ public class TDSavedQuery
         this.retryLimit = retryLimit;
         this.result = result;
         this.nextTime = nextTime;
+        this.engineVersion = engineVersion;
     }
 
     public String getId()
@@ -171,6 +177,11 @@ public class TDSavedQuery
         return nextTime;
     }
 
+    public TDJob.EngineVersion getEngineVersion()
+    {
+        return engineVersion;
+    }
+
     @Override
     public String toString()
     {
@@ -187,6 +198,7 @@ public class TDSavedQuery
                 ", retryLimit=" + retryLimit +
                 ", result='" + result + '\'' +
                 ", nextTime='" + nextTime + '\'' +
+                ", engineVersion='" + engineVersion + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryBuilder.java
@@ -33,6 +33,7 @@ public class TDSavedQueryBuilder
     private Optional<Integer> priority = Optional.absent();
     private Optional<Integer> retryLimit = Optional.absent();
     private Optional<String> result = Optional.absent();
+    private Optional<TDJob.EngineVersion> engineVersion = Optional.absent();
 
     public TDSavedQueryBuilder setName(String name)
     {
@@ -94,6 +95,12 @@ public class TDSavedQueryBuilder
         return this;
     }
 
+    public TDSavedQueryBuilder setEngineVersion(TDJob.EngineVersion engineVersion)
+    {
+        this.engineVersion = Optional.fromNullable(engineVersion);
+        return this;
+    }
+
     private static <T> void checkPresence(Optional<T> opt, String errorMessage)
     {
         if (!opt.isPresent()) {
@@ -119,7 +126,8 @@ public class TDSavedQueryBuilder
                 database.get(),
                 priority.or(TDJob.Priority.NORMAL.toInt()),
                 retryLimit.or(0),
-                result.or("")
+                result.or(""),
+                engineVersion.orNull()
         );
     }
 

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
@@ -42,6 +42,7 @@ public class TDSavedQueryUpdateRequest
     private final Optional<Integer> priority;
     private final Optional<Integer> retryLimit;
     private final Optional<String> result;
+    private final Optional<TDJob.EngineVersion> engineVersion;
 
     @VisibleForTesting
     @JsonCreator
@@ -55,7 +56,8 @@ public class TDSavedQueryUpdateRequest
             @JsonProperty("database") Optional<String> database,
             @JsonProperty("priority") Optional<Integer> priority,
             @JsonProperty("retry_limit") Optional<Integer> retryLimit,
-            @JsonProperty("result") Optional<String> result)
+            @JsonProperty("result") Optional<String> result,
+            @JsonProperty("engine_version") Optional<TDJob.EngineVersion> engineVersion)
     {
         this.name = name;
         this.cron = cron;
@@ -67,6 +69,7 @@ public class TDSavedQueryUpdateRequest
         this.priority = priority;
         this.retryLimit = retryLimit;
         this.result = result;
+        this.engineVersion = engineVersion;
     }
 
     @VisibleForTesting
@@ -109,7 +112,8 @@ public class TDSavedQueryUpdateRequest
                 database.or(base.getDatabase()),
                 priority.or(base.getPriority()),
                 retryLimit.or(base.getRetryLimit()),
-                result.or(base.getResult()));
+                result.or(base.getResult()),
+                engineVersion.isPresent() ? engineVersion.get() : base.getEngineVersion());
     }
 
     @JsonProperty
@@ -172,6 +176,12 @@ public class TDSavedQueryUpdateRequest
         return result;
     }
 
+    @JsonProperty
+    public Optional<TDJob.EngineVersion> getEngineVersion()
+    {
+        return engineVersion;
+    }
+
     @Override
     public String toString()
     {
@@ -186,6 +196,7 @@ public class TDSavedQueryUpdateRequest
                 ", priority=" + priority +
                 ", retryLimit=" + retryLimit +
                 ", result=" + result +
+                ", engineVersion=" + engineVersion +
                 '}';
     }
 
@@ -228,6 +239,9 @@ public class TDSavedQueryUpdateRequest
         if (retryLimit != null ? !retryLimit.equals(that.retryLimit) : that.retryLimit != null) {
             return false;
         }
+        if (engineVersion != null ? !engineVersion.equals(that.engineVersion) : that.engineVersion != null) {
+            return false;
+        }
         return result != null ? result.equals(that.result) : that.result == null;
     }
 
@@ -244,6 +258,7 @@ public class TDSavedQueryUpdateRequest
         result1 = 31 * result1 + (priority != null ? priority.hashCode() : 0);
         result1 = 31 * result1 + (retryLimit != null ? retryLimit.hashCode() : 0);
         result1 = 31 * result1 + (result != null ? result.hashCode() : 0);
+        result1 = 31 * result1 + (engineVersion != null ? engineVersion.hashCode() : 0);
         return result1;
     }
 }

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
@@ -176,7 +176,7 @@ public class TDSavedQueryUpdateRequest
         return result;
     }
 
-    @JsonProperty
+    @JsonProperty("engine_version")
     public Optional<TDJob.EngineVersion> getEngineVersion()
     {
         return engineVersion;

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequestBuilder.java
@@ -35,6 +35,7 @@ public class TDSavedQueryUpdateRequestBuilder
     private Optional<Integer> priority = Optional.absent();
     private Optional<Integer> retryLimit = Optional.absent();
     private Optional<String> result = Optional.absent();
+    private Optional<TDJob.EngineVersion> engineVersion = Optional.absent();
 
     TDSavedQueryUpdateRequestBuilder()
     {
@@ -52,7 +53,8 @@ public class TDSavedQueryUpdateRequestBuilder
                 database,
                 priority,
                 retryLimit,
-                result
+                result,
+                engineVersion
         );
     }
 
@@ -113,6 +115,12 @@ public class TDSavedQueryUpdateRequestBuilder
     public TDSavedQueryUpdateRequestBuilder setResult(String result)
     {
         this.result = Optional.of(result);
+        return this;
+    }
+
+    public TDSavedQueryUpdateRequestBuilder setEngineVersion(TDJob.EngineVersion engineVersion)
+    {
+        this.engineVersion = Optional.of(engineVersion);
         return this;
     }
 }

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -46,6 +46,7 @@ import com.treasuredata.client.model.TDExportJobRequest;
 import com.treasuredata.client.model.TDExportResultJobRequest;
 import com.treasuredata.client.model.TDImportResult;
 import com.treasuredata.client.model.TDJob;
+import com.treasuredata.client.model.TDJob.EngineVersion;
 import com.treasuredata.client.model.TDJobList;
 import com.treasuredata.client.model.TDJobRequest;
 import com.treasuredata.client.model.TDJobRequestBuilder;
@@ -435,7 +436,7 @@ public class TestTDClient
     {
         // Valid engine_version must be accepted
         try {
-            submitJobWithEngineVersion(TDJob.Type.PRESTO, Optional.of(TDJob.EngineVersion.STABLE));
+            submitJobWithEngineVersion(TDJob.Type.PRESTO, Optional.of(EngineVersion.fromString("stable")));
         }
         catch (Exception e) {
             fail("Unexpected exception:" + e.toString());
@@ -463,7 +464,7 @@ public class TestTDClient
     {
         // Valid engine_version must be accepted
         try {
-            submitJobWithEngineVersion(TDJob.Type.HIVE, Optional.of(TDJob.EngineVersion.STABLE));
+            submitJobWithEngineVersion(TDJob.Type.HIVE, Optional.of(EngineVersion.fromString("stable")));
         }
         catch (Exception e) {
             fail("Unexpected exception:" + e.toString());
@@ -1491,7 +1492,7 @@ public class TestTDClient
                 .setCron("0 * * * *")
                 .setPriority(-1)
                 .setRetryLimit(2)
-                .setEngineVersion(TDJob.EngineVersion.STABLE)
+                .setEngineVersion(EngineVersion.fromString("stable"))
                 .build();
 
         try {
@@ -1569,7 +1570,7 @@ public class TestTDClient
                 .setCron("0 * * * *")
                 .setPriority(-1)
                 .setRetryLimit(2)
-                .setEngineVersion(TDJob.EngineVersion.EXPERIMENTAL)
+                .setEngineVersion(EngineVersion.fromString("experimental"))
                 .build();
 
         try {
@@ -1581,7 +1582,7 @@ public class TestTDClient
             TDSavedQueryUpdateRequest query2 =
                     TDSavedQuery.newUpdateRequestBuilder()
                             .setQuery("select 2")
-                            .setEngineVersion(TDJob.EngineVersion.STABLE)
+                            .setEngineVersion(EngineVersion.fromString("stable"))
                             .build();
             TDSavedQuery updated = client.updateSavedQuery(queryName, query2);
         }
@@ -1612,7 +1613,7 @@ public class TestTDClient
                 .setCron("0 * * * *")
                 .setPriority(-1)
                 .setRetryLimit(2)
-                .setEngineVersion(TDJob.EngineVersion.EXPERIMENTAL)
+                .setEngineVersion(EngineVersion.fromString("experimental"))
                 .build();
 
         try {


### PR DESCRIPTION
I would like to introduce **engine_version** parameter to Hive,Presto experimentally.
Currently _EXPERIMENTAL_, _STABLE_, _LEGACY_, _CURRENT_ are pre-defined as engine version. But limited versions are avilable. It depends on Engine.

 
