### PR TITLE
CVE-2019-9658 Fix security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.19</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Fix security issue by upgrading checkstyle to 8.18, see: https://nvd.nist.gov/vuln/detail/CVE-2019-9658