### PR TITLE
Add support to API key validation endpoint

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.treasuredata.client.model.ObjectMappers;
+import com.treasuredata.client.model.TDApiKey;
 import com.treasuredata.client.model.TDAuthenticationResult;
 import com.treasuredata.client.model.TDBulkImportParts;
 import com.treasuredata.client.model.TDBulkImportSession;
@@ -310,6 +311,12 @@ public class TDClient
     public TDUser getUser()
     {
         return doGet("/v3/user/show", TDUser.class);
+    }
+
+    @Override
+    public TDApiKey validateApiKey()
+    {
+        return doGet("/v3/user/apikey/validate", TDApiKey.class);
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -21,7 +21,7 @@ package com.treasuredata.client;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.Multimap;
-
+import com.treasuredata.client.model.TDApiKey;
 import com.treasuredata.client.model.TDBulkImportSession;
 import com.treasuredata.client.model.TDBulkLoadSessionStartRequest;
 import com.treasuredata.client.model.TDBulkLoadSessionStartResult;
@@ -90,6 +90,12 @@ public interface TDClientApi<ClientImpl>
      * @return A {@link TDUser} instance.
      */
     TDUser getUser();
+
+    /**
+     * Validates and return information about the current API key.
+     * @return A {@link TDApiKey} instance.
+     */
+    TDApiKey validateApiKey();
 
     /**
      * List the users in the current account.

--- a/src/main/java/com/treasuredata/client/model/TDApiKey.java
+++ b/src/main/java/com/treasuredata/client/model/TDApiKey.java
@@ -1,0 +1,32 @@
+package com.treasuredata.client.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@JsonSerialize(as = ImmutableTDApiKey.class)
+@JsonDeserialize(as = ImmutableTDApiKey.class)
+public abstract class TDApiKey
+{
+    @JsonProperty("key_type") public abstract String getKeyType();
+    @JsonProperty("account_id") public abstract Integer getAccountId();
+    @JsonProperty("user_id") public abstract Integer getUserId();
+    @JsonProperty("administrator") public abstract boolean isAdministrator();
+
+    public interface Builder
+    {
+        Builder keyType(String keyType);
+        Builder accountId(Integer accountId);
+        Builder userId(Integer userId);
+        Builder isAdministrator(boolean administrator);
+        TDApiKey build();
+    }
+
+    public static Builder builder()
+    {
+        return ImmutableTDApiKey.builder();
+    }
+}

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 import com.treasuredata.client.model.ObjectMappers;
+import com.treasuredata.client.model.TDApiKey;
 import com.treasuredata.client.model.TDBulkImportSession;
 import com.treasuredata.client.model.TDBulkLoadSessionStartRequest;
 import com.treasuredata.client.model.TDBulkLoadSessionStartResult;
@@ -112,7 +113,6 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import static com.treasuredata.client.TDClientConfig.ENV_TD_CLIENT_APIKEY;
-
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -1354,6 +1354,34 @@ public class TestTDClient
     {
         TDUser user = client.getUser();
         logger.trace("user: {}", user);
+    }
+
+    @Test
+    public void validateApiKeyMocked()
+            throws Exception
+    {
+        client = mockClient();
+
+        String expectedKeyJson = "{\"user_id\":1,\"account_id\":2,\"key_type\":\"normal\",\"administrator\":true}";
+
+        TDApiKey expectedKey = ObjectMappers.compactMapper().readValue(expectedKeyJson, TDApiKey.class);
+
+        server.enqueue(new MockResponse().setBody(expectedKeyJson));
+
+        TDApiKey key = client.validateApiKey();
+
+        assertThat(key, is(expectedKey));
+
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getPath(), is("/v3/user/apikey/validate"));
+    }
+
+    @Test
+    public void validateApiKey()
+            throws Exception
+    {
+        TDApiKey key = client.validateApiKey();
+        logger.trace("api_key: {}", key);
     }
 
     @Test


### PR DESCRIPTION
Add support to API key validation endpoint, it allows to validate and collect information about the API key currently used.