### PR TITLE
Support idempotent key in createTable

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -290,6 +290,20 @@ public class TDClient
         return httpClient.call(request, apiKeyCache);
     }
 
+    protected String doPost(String path, Map<String, String> queryParam)
+            throws TDClientException
+    {
+        checkNotNull(path, "path is null");
+        checkNotNull(queryParam, "param is null");
+
+        TDApiRequest.Builder request = TDApiRequest.Builder.POST(path);
+        for (Map.Entry<String, String> e : queryParam.entrySet()) {
+            request.addQueryParam(e.getKey(), e.getValue());
+        }
+
+        return httpClient.call(request.build(), apiKeyCache);
+    }
+
     protected String doPut(String path, File filePath)
             throws TDClientException
     {
@@ -464,6 +478,15 @@ public class TDClient
             throws TDClientException
     {
         doPost(buildUrl("/v3/table/create", databaseName, validateTableName(tableName), TDTableType.LOG.getTypeName()));
+    }
+
+    @Override
+    public void createTable(String databaseName, String tableName, String idempotentKey)
+            throws TDClientException
+    {
+        // Idempotent key support is EXPERIMENTAL.
+        doPost(buildUrl("/v3/table/create", databaseName, validateTableName(tableName), TDTableType.LOG.getTypeName()),
+                ImmutableMap.of("idempotent_key", idempotentKey));
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -176,6 +176,14 @@ public interface TDClientApi<ClientImpl>
      */
     void createTable(String databaseName, String tableName);
 
+    /**
+     * EXPERIMENTAL: Create a new table with idempotent retry
+     * @param databaseName
+     * @param tableName
+     * @param idempotentKey
+     */
+    void createTable(String databaseName, String tableName, String idempotentKey);
+
     void createTableIfNotExists(String databaseName, String tableName);
 
     void renameTable(String databaseName, String tableName, String newTableName);

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -968,6 +968,40 @@ public class TestTDClient
         }
     }
 
+    @Test(expected = TDClientException.class)
+    public void createTableWithoutIdempotentKey()
+            throws Exception
+    {
+        String t = newTemporaryName("non_idempotent_test");
+        try {
+            // It should throw TDClientException without idempotent key.
+            client.createTable(SAMPLE_DB, t);
+            client.createTable(SAMPLE_DB, t);
+        }
+        finally {
+            client.deleteTable(SAMPLE_DB, t);
+        }
+    }
+
+    @Test
+    public void createTableWithIdempotentKey()
+            throws Exception
+    {
+        String t = newTemporaryName("idempotent_test");
+        try {
+            String idempotentKey = "idempotent_key";
+            client.createTable(SAMPLE_DB, t, idempotentKey);
+            client.createTable(SAMPLE_DB, t, idempotentKey);
+        }
+        catch (TDClientException e) {
+            // Duplicated request must not throw exception with idempotent key.
+            fail();
+        }
+        finally {
+            client.deleteTable(SAMPLE_DB, t);
+        }
+    }
+
     private String queryResult(String database, String sql)
             throws InterruptedException
     {


### PR DESCRIPTION
Idempotent key enables us to retry create table request idempotently. We can update td-client to support this kind of request experimentally. 