### PR TITLE
Shade/relocate Guava for all-in-one jar by maven-shade-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.1.0</version>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.google</pattern>
+              <shadedPattern>com.treasuredata.client.com.google</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
This PR relocates Guava 21.0 in all-in-one jar generated by maven-shade-plugin to avoid class loading issues. several Java libraries depends on different versions of Guava.