### PR TITLE
Initial effort to remove Guava dependency. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,14 @@
       <version>2.9.9</version>
     </dependency>
 
+    <!-- Required for generated code to properly use java.util.Optional -->
+    <!-- https://www.baeldung.com/jackson-optional -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>2.9.9</version>
+    </dependency>
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -18,10 +18,10 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.treasuredata.client.TDClientConfig.ENV_TD_CLIENT_APIKEY;
@@ -50,13 +50,13 @@ import static com.treasuredata.client.TDClientConfig.getTDConfProperties;
  */
 public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends AbstractTDClientBuilder<ClientImpl, BuilderImpl>>
 {
-    protected Optional<String> endpoint = Optional.absent();
-    protected Optional<Integer> port = Optional.absent();
+    protected Optional<String> endpoint = Optional.empty();
+    protected Optional<Integer> port = Optional.empty();
     protected boolean useSSL = true;
-    protected Optional<String> apiKey = Optional.absent();
-    protected Optional<String> user = Optional.absent();
-    protected Optional<String> password = Optional.absent();
-    protected Optional<ProxyConfig> proxy = Optional.absent();
+    protected Optional<String> apiKey = Optional.empty();
+    protected Optional<String> user = Optional.empty();
+    protected Optional<String> password = Optional.empty();
+    protected Optional<ProxyConfig> proxy = Optional.empty();
     protected int retryLimit = 7;
     protected int retryInitialIntervalMillis = 500;
     protected int retryMaxIntervalMillis = 60000;
@@ -73,7 +73,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
 
     private static Optional<String> getConfigProperty(Properties p, String key)
     {
-        return Optional.fromNullable(p.getProperty(key));
+        return Optional.ofNullable(p.getProperty(key));
     }
 
     private static Optional<Integer> getConfigPropertyInt(Properties p, TDClientConfig.Type key)
@@ -93,7 +93,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
             }
         }
         else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -114,7 +114,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
             }
         }
         else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -130,7 +130,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
             }
         }
         else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -169,24 +169,29 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
      */
     public BuilderImpl setProperties(Properties p)
     {
-        this.endpoint = getConfigProperty(p, API_ENDPOINT)
-                .or(getConfigProperty(p, "endpoint"))
-                .or(endpoint);
-        this.port = getConfigPropertyInt(p, API_PORT)
-                .or(getConfigPropertyInt(p, "port"))
-                .or(port);
-        this.useSSL = getConfigPropertyBoolean(p, USESSL)
-                .or(getConfigPropertyBoolean(p, "usessl"))
-                .or(useSSL);
-        this.apiKey = getConfigProperty(p, APIKEY)
-                .or(getConfigProperty(p, "apikey"))
-                .or(apiKey);
-        this.user = getConfigProperty(p, USER)
-                .or(getConfigProperty(p, "user"))
-                .or(user);
-        this.password = getConfigProperty(p, PASSOWRD)
-                .or(getConfigProperty(p, "password"))
-                .or(password);
+        this.endpoint = getConfigProperty(p, API_ENDPOINT).isPresent()
+                ? getConfigProperty(p, API_ENDPOINT) : getConfigProperty(p, "endpoint").isPresent()
+                ? getConfigProperty(p, "endpoint") : endpoint;
+
+        this.port = getConfigPropertyInt(p, API_PORT).isPresent()
+                ? getConfigPropertyInt(p, API_PORT) : getConfigPropertyInt(p, "port").isPresent()
+                ? getConfigPropertyInt(p, "port") : port;
+
+        this.useSSL = getConfigPropertyBoolean(p, USESSL).isPresent()
+                ? getConfigPropertyBoolean(p, USESSL).get() : getConfigPropertyBoolean(p, "usessl").isPresent()
+                ? getConfigPropertyBoolean(p, "usessl").get() : useSSL;
+
+        this.apiKey = getConfigProperty(p, APIKEY).isPresent()
+                ? getConfigProperty(p, APIKEY) : getConfigProperty(p, "apikey").isPresent()
+                ? getConfigProperty(p, "apikey") : apiKey;
+
+        this.user = getConfigProperty(p, USER).isPresent()
+                ? getConfigProperty(p, USER) : getConfigProperty(p, "user").isPresent()
+                ? getConfigProperty(p, "user") : user;
+
+        this.password = getConfigProperty(p, PASSOWRD).isPresent()
+                ? getConfigProperty(p, PASSOWRD) : getConfigProperty(p, "password").isPresent()
+                ? getConfigProperty(p, "password") : password;
 
         // proxy
         boolean hasProxy = false;
@@ -223,16 +228,24 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
             hasProxy = true;
             proxyConfig.setPassword(proxyPassword.get());
         }
-        this.proxy = Optional.fromNullable(hasProxy ? proxyConfig.createProxyConfig() : null);
+        this.proxy = Optional.ofNullable(hasProxy ? proxyConfig.createProxyConfig() : null);
 
         // http client parameter
-        this.retryLimit = getConfigPropertyInt(p, RETRY_LIMIT).or(retryLimit);
-        this.retryInitialIntervalMillis = getConfigPropertyInt(p, RETRY_INITIAL_INTERVAL_MILLIS).or(retryInitialIntervalMillis);
-        this.retryMaxIntervalMillis = getConfigPropertyInt(p, RETRY_MAX_INTERVAL_MILLIS).or(retryMaxIntervalMillis);
-        this.retryMultiplier = getConfigPropertyDouble(p, RETRY_MULTIPLIER).or(retryMultiplier);
-        this.connectTimeoutMillis = getConfigPropertyInt(p, CONNECT_TIMEOUT_MILLIS).or(connectTimeoutMillis);
-        this.readTimeoutMillis = getConfigPropertyInt(p, READ_TIMEOUT_MILLIS).or(readTimeoutMillis);
-        this.connectionPoolSize = getConfigPropertyInt(p, CONNECTION_POOL_SIZE).or(connectionPoolSize);
+
+        this.retryLimit = getConfigPropertyInt(p, RETRY_LIMIT).isPresent()
+                ? getConfigPropertyInt(p, RETRY_LIMIT).get() : retryLimit;
+        this.retryInitialIntervalMillis = getConfigPropertyInt(p, RETRY_INITIAL_INTERVAL_MILLIS).isPresent()
+                ? getConfigPropertyInt(p, RETRY_INITIAL_INTERVAL_MILLIS).get() : retryInitialIntervalMillis;
+        this.retryMaxIntervalMillis = getConfigPropertyInt(p, RETRY_MAX_INTERVAL_MILLIS).isPresent()
+                ? getConfigPropertyInt(p, RETRY_MAX_INTERVAL_MILLIS).get() : retryMaxIntervalMillis;
+        this.retryMultiplier = getConfigPropertyDouble(p, RETRY_MULTIPLIER).isPresent()
+                ? getConfigPropertyDouble(p, RETRY_MULTIPLIER).get() : retryMultiplier;
+        this.connectTimeoutMillis = getConfigPropertyInt(p, CONNECT_TIMEOUT_MILLIS).isPresent()
+                ? getConfigPropertyInt(p, CONNECT_TIMEOUT_MILLIS).get() : connectTimeoutMillis;
+        this.readTimeoutMillis = getConfigPropertyInt(p, READ_TIMEOUT_MILLIS).isPresent()
+                ? getConfigPropertyInt(p, READ_TIMEOUT_MILLIS).get() : readTimeoutMillis;
+        this.connectionPoolSize = getConfigPropertyInt(p, CONNECTION_POOL_SIZE).isPresent()
+                ? getConfigPropertyInt(p, CONNECTION_POOL_SIZE).get() : connectionPoolSize;
 
         return self();
     }

--- a/src/main/java/com/treasuredata/client/ProxyConfig.java
+++ b/src/main/java/com/treasuredata/client/ProxyConfig.java
@@ -18,10 +18,10 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
-
 import java.net.URI;
 import java.net.URISyntaxException;
+
+import java.util.Optional;
 
 /**
  * Proxy configuration to access TD API
@@ -102,8 +102,8 @@ public class ProxyConfig
         private String host = "localhost";
         private int port = 8080;
         private boolean useSSL = false;
-        private Optional<String> user = Optional.absent();
-        private Optional<String> password = Optional.absent();
+        private Optional<String> user = Optional.empty();
+        private Optional<String> password = Optional.empty();
 
         public ProxyConfigBuilder()
         {

--- a/src/main/java/com/treasuredata/client/TDApiRequest.java
+++ b/src/main/java/com/treasuredata/client/TDApiRequest.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -32,6 +31,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -142,12 +142,12 @@ public class TDApiRequest
         private String path;
         private Map<String, String> queryParams;
         private ImmutableMultimap.Builder<String, String> headerParams;
-        private Optional<String> postJson = Optional.absent();
-        private Optional<File> file = Optional.absent();
-        private Optional<byte[]> content = Optional.absent();
+        private Optional<String> postJson = Optional.empty();
+        private Optional<File> file = Optional.empty();
+        private Optional<byte[]> content = Optional.empty();
         private int contentOffset;
         private int contentLength;
-        private Optional<Boolean> followRedirects = Optional.absent();
+        private Optional<Boolean> followRedirects = Optional.empty();
 
         Builder(TDHttpMethod method, String path)
         {

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -76,6 +75,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -237,13 +237,13 @@ public class TDClient
     protected <ResultType> ResultType doPost(String path, Class<ResultType> resultTypeClass)
             throws TDClientException
     {
-        return this.<ResultType>doPost(path, ImmutableMap.<String, String>of(), Optional.<String>absent(), resultTypeClass);
+        return this.<ResultType>doPost(path, ImmutableMap.<String, String>of(), Optional.<String>empty(), resultTypeClass);
     }
 
     protected <ResultType> ResultType doPost(String path, Map<String, String> queryParam, Class<ResultType> resultTypeClass)
             throws TDClientException
     {
-        return this.<ResultType>doPost(path, queryParam, Optional.<String>absent(), resultTypeClass);
+        return this.<ResultType>doPost(path, queryParam, Optional.<String>empty(), resultTypeClass);
     }
 
     protected <ResultType> ResultType doPut(String path, Map<String, String> queryParam, File file, Class<ResultType> resultTypeClass)
@@ -343,7 +343,7 @@ public class TDClient
     public String serverStatus()
     {
         // No API key is requried for server_status
-        return httpClient.call(TDApiRequest.Builder.GET("/v3/system/server_status").build(), Optional.<String>absent());
+        return httpClient.call(TDApiRequest.Builder.GET("/v3/system/server_status").build(), Optional.<String>empty());
     }
 
     @Override
@@ -654,7 +654,7 @@ public class TDClient
                 doPost(
                         buildUrl("/v3/job/issue", jobRequest.getType().getType(), jobRequest.getDatabase()),
                         queryParam,
-                        jobRequest.getConfig().transform(new Function<ObjectNode, String>()
+                        jobRequest.getConfig().map(new Function<ObjectNode, String>()
                         {
                             public String apply(ObjectNode config)
                             {
@@ -781,13 +781,13 @@ public class TDClient
     @Override
     public void performBulkImportSession(String sessionName, TDJob.Priority priority)
     {
-        performBulkImportSession(sessionName, Optional.absent(), priority);
+        performBulkImportSession(sessionName, Optional.empty(), priority);
     }
 
     @Override
     public void performBulkImportSession(String sessionName, Optional<String> poolName, TDJob.Priority priority)
     {
-        Optional<String> jsonBody = Optional.absent();
+        Optional<String> jsonBody = Optional.empty();
         if (poolName.isPresent()) {
             jsonBody = Optional.of(JSONObject.toJSONString(ImmutableMap.of("pool_name", poolName.get())));
         }
@@ -1062,7 +1062,7 @@ public class TDClient
             return Optional.of(distribution);
         }
         catch (TDClientHttpNotFoundException e) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -19,7 +19,6 @@
 package com.treasuredata.client;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.collect.Multimap;
 import com.treasuredata.client.model.TDApiKey;
 import com.treasuredata.client.model.TDBulkImportSession;
@@ -50,6 +49,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Treasure Data Client API

--- a/src/main/java/com/treasuredata/client/TDClientConfig.java
+++ b/src/main/java/com/treasuredata/client/TDClientConfig.java
@@ -19,7 +19,6 @@
 package com.treasuredata.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.google.common.io.Files;
@@ -33,6 +32,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 /**
@@ -122,7 +122,7 @@ public class TDClientConfig
             int connectionPoolSize,
             Multimap<String, String> headers)
     {
-        this.endpoint = endpoint.or("api.treasuredata.com");
+        this.endpoint = endpoint.orElse("api.treasuredata.com");
         this.port = port;
         this.useSSL = useSSL;
         this.apiKey = apiKey;

--- a/src/main/java/com/treasuredata/client/TDClientException.java
+++ b/src/main/java/com/treasuredata/client/TDClientException.java
@@ -18,7 +18,7 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -84,7 +84,7 @@ public class TDClientException
 
     public TDClientException(ErrorType errorType, String message)
     {
-        this(errorType, message, Optional.<Exception>absent());
+        this(errorType, message, Optional.<Exception>empty());
     }
 
     public ErrorType getErrorType()

--- a/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpConflictException.java
@@ -18,7 +18,7 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 /**
  * On 409 conflict error (e.g., database already exists)
@@ -42,6 +42,6 @@ public class TDClientHttpConflictException
 
     public Optional<String> getConflictsWith()
     {
-        return Optional.fromNullable(conflictsWith);
+        return Optional.ofNullable(conflictsWith);
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientHttpException.java
+++ b/src/main/java/com/treasuredata/client/TDClientHttpException.java
@@ -18,9 +18,8 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
-
 import java.util.Date;
+import java.util.Optional;
 
 /**
  * Exception class for reporting http server status code
@@ -47,7 +46,7 @@ public class TDClientHttpException
     public Optional<Date> getRetryAfter()
     {
         if (retryAfter == -1) {
-            return Optional.absent();
+            return Optional.empty();
         }
         else {
             return Optional.of(new Date(retryAfter));

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -1,7 +1,6 @@
 package com.treasuredata.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.treasuredata.client.model.TDApiErrorMessage;
 import okhttp3.Response;
 import org.slf4j.Logger;
@@ -25,6 +24,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -246,7 +246,7 @@ public class TDRequestErrorHandler
     @VisibleForTesting
     public static Optional<TDApiErrorMessage> extractErrorResponse(Response response)
     {
-        Optional<String> content = Optional.absent();
+        Optional<String> content = Optional.empty();
         try {
             try {
                 content = Optional.of(response.body().string());
@@ -261,12 +261,12 @@ public class TDRequestErrorHandler
             }
             else {
                 // Error message from Proxy server etc.
-                return Optional.of(new TDApiErrorMessage("error", content.or("[empty]"), "error"));
+                return Optional.of(new TDApiErrorMessage("error", content.orElse("[empty]"), "error"));
             }
         }
         catch (IOException e) {
-            logger.warn("Failed to parse the error response {}: {}\n{}", response.request().url(), content.or("[empty]"), e.getMessage());
+            logger.warn("Failed to parse the error response {}: {}\n{}", response.request().url(), content.orElse("[empty]"), e.getMessage());
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client.impl;
 
-import com.google.common.base.Optional;
 import com.treasuredata.client.ProxyConfig;
 import com.treasuredata.client.TDClientException;
 import com.treasuredata.client.TDClientHttpException;
@@ -31,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static com.google.common.net.HttpHeaders.PROXY_AUTHORIZATION;
 
@@ -42,7 +42,7 @@ public class ProxyAuthenticator
 {
     private final Logger logger = LoggerFactory.getLogger(ProxyAuthenticator.class);
     private final ProxyConfig proxyConfig;
-    private Optional<String> proxyAuthCache = Optional.absent();
+    private Optional<String> proxyAuthCache = Optional.empty();
 
     public ProxyAuthenticator(ProxyConfig proxyConfig)
     {
@@ -62,7 +62,7 @@ public class ProxyAuthenticator
         if (!proxyAuthCache.isPresent()) {
             logger.debug("Proxy authorization requested for " + route.address());
             proxyAuthCache = Optional.of(
-                    Credentials.basic(proxyConfig.getUser().or(""), proxyConfig.getPassword().or(""))
+                    Credentials.basic(proxyConfig.getUser().orElse(""), proxyConfig.getPassword().orElse(""))
             );
         }
         return response.request().newBuilder()

--- a/src/main/java/com/treasuredata/client/model/ObjectMappers.java
+++ b/src/main/java/com/treasuredata/client/model/ObjectMappers.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -36,6 +37,7 @@ public class ObjectMappers
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JsonOrgModule());
         mapper.registerModule(new GuavaModule().configureAbsentsAsNulls(false));
+        mapper.registerModule(new Jdk8Module());
         mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return mapper;

--- a/src/main/java/com/treasuredata/client/model/TDBulkLoadSessionStartRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDBulkLoadSessionStartRequest.java
@@ -2,7 +2,8 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
+
+import java.util.Optional;
 
 public class TDBulkLoadSessionStartRequest
 {
@@ -21,20 +22,20 @@ public class TDBulkLoadSessionStartRequest
 
     TDBulkLoadSessionStartRequest(TDBulkLoadSessionStartRequestBuilder builder)
     {
-        this.scheduledTime = builder.getScheduledTime().orNull();
-        this.domainKey = builder.getDomainKey().orNull();
+        this.scheduledTime = builder.getScheduledTime().orElse(null);
+        this.domainKey = builder.getDomainKey().orElse(null);
     }
 
     @JsonProperty("scheduled_time")
     public Optional<String> getScheduledTime()
     {
-        return Optional.fromNullable(scheduledTime);
+        return Optional.ofNullable(scheduledTime);
     }
 
     @JsonProperty("domain_key")
     public Optional<String> getDomainKey()
     {
-        return Optional.fromNullable(domainKey);
+        return Optional.ofNullable(domainKey);
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/model/TDBulkLoadSessionStartRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDBulkLoadSessionStartRequestBuilder.java
@@ -1,6 +1,6 @@
 package com.treasuredata.client.model;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 public class TDBulkLoadSessionStartRequestBuilder
 {
@@ -13,7 +13,7 @@ public class TDBulkLoadSessionStartRequestBuilder
 
     public Optional<String> getScheduledTime()
     {
-        return Optional.fromNullable(scheduledTime);
+        return Optional.ofNullable(scheduledTime);
     }
 
     public TDBulkLoadSessionStartRequestBuilder setScheduledTime(String scheduledTime)
@@ -29,13 +29,13 @@ public class TDBulkLoadSessionStartRequestBuilder
 
     public TDBulkLoadSessionStartRequestBuilder setScheduledTime(Optional<String> scheduledTime)
     {
-        this.scheduledTime = scheduledTime.orNull();
+        this.scheduledTime = scheduledTime.orElse(null);
         return this;
     }
 
     public Optional<String> getDomainKey()
     {
-        return Optional.fromNullable(domainKey);
+        return Optional.ofNullable(domainKey);
     }
 
     public TDBulkLoadSessionStartRequestBuilder setDomainKey(String domainKey)
@@ -46,7 +46,7 @@ public class TDBulkLoadSessionStartRequestBuilder
 
     public TDBulkLoadSessionStartRequestBuilder setDomainKey(Optional<String> domainKey)
     {
-        return setDomainKey(domainKey.orNull());
+        return setDomainKey(domainKey.orElse(null));
     }
 
     public TDBulkLoadSessionStartRequest build()

--- a/src/main/java/com/treasuredata/client/model/TDColumnType.java
+++ b/src/main/java/com/treasuredata/client/model/TDColumnType.java
@@ -20,21 +20,21 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.treasuredata.client.model.impl.TDColumnTypeDeserializer;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 
 @JsonDeserialize(using = TDColumnTypeDeserializer.class)
 public class TDColumnType implements Serializable
 {
-    public static final TDColumnType INT = new TDColumnType(TDTypeName.INT, Optional.<List<TDColumnType>>absent());
-    public static final TDColumnType LONG = new TDColumnType(TDTypeName.LONG, Optional.<List<TDColumnType>>absent());
-    public static final TDColumnType FLOAT = new TDColumnType(TDTypeName.FLOAT, Optional.<List<TDColumnType>>absent());
-    public static final TDColumnType DOUBLE = new TDColumnType(TDTypeName.DOUBLE, Optional.<List<TDColumnType>>absent());
-    public static final TDColumnType STRING = new TDColumnType(TDTypeName.STRING, Optional.<List<TDColumnType>>absent());
+    public static final TDColumnType INT = new TDColumnType(TDTypeName.INT, Optional.<List<TDColumnType>>empty());
+    public static final TDColumnType LONG = new TDColumnType(TDTypeName.LONG, Optional.<List<TDColumnType>>empty());
+    public static final TDColumnType FLOAT = new TDColumnType(TDTypeName.FLOAT, Optional.<List<TDColumnType>>empty());
+    public static final TDColumnType DOUBLE = new TDColumnType(TDTypeName.DOUBLE, Optional.<List<TDColumnType>>empty());
+    public static final TDColumnType STRING = new TDColumnType(TDTypeName.STRING, Optional.<List<TDColumnType>>empty());
 
     public static final List<TDColumnType> primitiveTypes = ImmutableList.of(INT, LONG, FLOAT, DOUBLE, STRING);
 
@@ -49,12 +49,13 @@ public class TDColumnType implements Serializable
     }
 
     private final TDTypeName typeName;
-    private final Optional<List<TDColumnType>> elementTypes;
+    //private final Optional<List<TDColumnType>> elementTypes;
+    private final List<TDColumnType> elementTypes;
 
     private TDColumnType(TDTypeName typeName, Optional<List<TDColumnType>> elementTypes)
     {
         this.typeName = typeName;
-        this.elementTypes = elementTypes;
+        this.elementTypes = elementTypes.isPresent() ? elementTypes.get() : null;
     }
 
     public TDTypeName getTypeName()
@@ -64,7 +65,7 @@ public class TDColumnType implements Serializable
 
     public boolean isPrimitive()
     {
-        return !elementTypes.isPresent();
+        return elementTypes == null;
     }
 
     public boolean isArrayType()
@@ -82,7 +83,7 @@ public class TDColumnType implements Serializable
         if (!isArrayType()) {
             throw new UnsupportedOperationException("getArrayElementType is not supported for " + this);
         }
-        return elementTypes.get().get(0);
+        return elementTypes.get(0);
     }
 
     public TDColumnType getMapKeyType()
@@ -90,7 +91,7 @@ public class TDColumnType implements Serializable
         if (!isMapType()) {
             throw new UnsupportedOperationException("getmapKeyType is not supported for " + this);
         }
-        return elementTypes.get().get(0);
+        return elementTypes.get(0);
     }
 
     public TDColumnType getMapValueType()
@@ -98,7 +99,7 @@ public class TDColumnType implements Serializable
         if (!isMapType()) {
             throw new UnsupportedOperationException("getMapValueType is not supported for " + this);
         }
-        return elementTypes.get().get(1);
+        return elementTypes.get(1);
     }
 
     @JsonValue

--- a/src/main/java/com/treasuredata/client/model/TDColumnType.java
+++ b/src/main/java/com/treasuredata/client/model/TDColumnType.java
@@ -49,7 +49,6 @@ public class TDColumnType implements Serializable
     }
 
     private final TDTypeName typeName;
-    //private final Optional<List<TDColumnType>> elementTypes;
     private final List<TDColumnType> elementTypes;
 
     private TDColumnType(TDTypeName typeName, Optional<List<TDColumnType>> elementTypes)

--- a/src/main/java/com/treasuredata/client/model/TDDatabase.java
+++ b/src/main/java/com/treasuredata/client/model/TDDatabase.java
@@ -21,7 +21,8 @@ package com.treasuredata.client.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
+
+import java.util.Optional;
 
 @JsonCollectionRootName(value = "databases")
 public class TDDatabase

--- a/src/main/java/com/treasuredata/client/model/TDExportJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDExportJobRequest.java
@@ -18,11 +18,11 @@
  */
 package com.treasuredata.client.model;
 
-import com.google.common.base.Optional;
 import org.immutables.builder.Builder;
 import org.immutables.value.Value;
 
 import java.util.Date;
+import java.util.Optional;
 
 /**
  *
@@ -68,7 +68,7 @@ public class TDExportJobRequest
         this.bucketName = bucketName;
         this.filePrefix = filePrefix;
         this.poolName = poolName;
-        this.domainKey = Optional.absent();
+        this.domainKey = Optional.empty();
     }
 
     private TDExportJobRequest(String database, String table, Date from, Date to, TDExportFileFormatType fileFormat, String accessKeyId, String secretAccessKey, String bucketName, String filePrefix, Optional<String> poolName, Optional<String> domainKey)

--- a/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDExportResultJobRequest.java
@@ -1,8 +1,9 @@
 package com.treasuredata.client.model;
 
-import com.google.common.base.Optional;
 import org.immutables.builder.Builder;
 import org.immutables.value.Value;
+
+import java.util.Optional;
 
 @Value.Style(typeBuilder = "TDExportResultJobRequestBuilder")
 public class TDExportResultJobRequest
@@ -47,9 +48,9 @@ public class TDExportResultJobRequest
             Optional<String> resultConnectionSettings)
     {
         return new TDExportResultJobRequest(jobId,
-                resultOutput.or(""),
-                resultConnectionId.or(""),
-                resultConnectionSettings.or(""));
+                resultOutput.orElse(""),
+                resultConnectionId.orElse(""),
+                resultConnectionSettings.orElse(""));
     }
 
     public static TDExportResultJobRequestBuilder builder()

--- a/src/main/java/com/treasuredata/client/model/TDJob.java
+++ b/src/main/java/com/treasuredata/client/model/TDJob.java
@@ -22,7 +22,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
+
+import java.util.Optional;
 
 /**
  *
@@ -153,12 +154,12 @@ public class TDJob
 
         public String getCmdout()
         {
-            return cmdout.or("");
+            return cmdout.orElse("");
         }
 
         public String getStderr()
         {
-            return stderr.or("");
+            return stderr.orElse("");
         }
 
         @Override
@@ -346,14 +347,14 @@ public class TDJob
      */
     public String getCmdOut()
     {
-        return debug.transform(new Function<Debug, String>()
+        return debug.map(new Function<Debug, String>()
         {
             @Override
             public String apply(Debug input)
             {
                 return input.getCmdout();
             }
-        }).or("");
+        }).orElse("");
     }
 
     /**
@@ -363,14 +364,14 @@ public class TDJob
      */
     public String getStdErr()
     {
-        return debug.transform(new Function<Debug, String>()
+        return debug.map(new Function<Debug, String>()
         {
             @Override
             public String apply(Debug input)
             {
                 return input.getStderr();
             }
-        }).or("");
+        }).orElse("");
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/model/TDJobList.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobList.java
@@ -20,9 +20,9 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  *

--- a/src/main/java/com/treasuredata/client/model/TDJobRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequest.java
@@ -19,7 +19,8 @@
 package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Optional;
+
+import java.util.Optional;
 
 /**
  *
@@ -53,11 +54,11 @@ public class TDJobRequest
         this.poolName = poolName;
         this.table = table;
         this.config = config;
-        this.scheduledTime = Optional.absent();
-        this.domainKey = Optional.absent();
-        this.resultConnectionId = Optional.absent();
-        this.resultConnectionSettings = Optional.absent();
-        this.engineVersion = Optional.absent();
+        this.scheduledTime = Optional.empty();
+        this.domainKey = Optional.empty();
+        this.resultConnectionId = Optional.empty();
+        this.resultConnectionSettings = Optional.empty();
+        this.engineVersion = Optional.empty();
     }
 
     private TDJobRequest(TDJobRequestBuilder builder)

--- a/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDJobRequestBuilder.java
@@ -19,7 +19,8 @@
 package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Optional;
+
+import java.util.Optional;
 
 public class TDJobRequestBuilder
 {
@@ -28,15 +29,15 @@ public class TDJobRequestBuilder
     private String query;
     private TDJob.Priority priority = TDJob.Priority.NORMAL;
     private String result;
-    private Optional<Integer> retryLimit = Optional.absent();
+    private Optional<Integer> retryLimit = Optional.empty();
     private String poolName;
-    private Optional<String> table = Optional.absent();
-    private Optional<ObjectNode> config = Optional.absent();
-    private Optional<Long> scheduledTime = Optional.absent();
-    private Optional<String> domainKey = Optional.absent();
-    private Optional<Long> resultConnectionId = Optional.absent();
-    private Optional<String> resultConnectionSettings = Optional.absent();
-    private Optional<TDJob.EngineVersion> engineVersion = Optional.absent();
+    private Optional<String> table = Optional.empty();
+    private Optional<ObjectNode> config = Optional.empty();
+    private Optional<Long> scheduledTime = Optional.empty();
+    private Optional<String> domainKey = Optional.empty();
+    private Optional<Long> resultConnectionId = Optional.empty();
+    private Optional<String> resultConnectionSettings = Optional.empty();
+    private Optional<TDJob.EngineVersion> engineVersion = Optional.empty();
 
     public TDJobRequestBuilder setResultOutput(String result)
     {
@@ -46,7 +47,7 @@ public class TDJobRequestBuilder
 
     public Optional<String> getResultOutput()
     {
-        return Optional.fromNullable(result);
+        return Optional.ofNullable(result);
     }
 
     public TDJobRequestBuilder setDatabase(String database)
@@ -124,7 +125,7 @@ public class TDJobRequestBuilder
 
     public Optional<String> getPoolName()
     {
-        return Optional.fromNullable(poolName);
+        return Optional.ofNullable(poolName);
     }
 
     public TDJobRequestBuilder setTable(String table)
@@ -151,7 +152,7 @@ public class TDJobRequestBuilder
 
     public TDJobRequestBuilder setScheduledTime(Long scheduledTime)
     {
-        return setScheduledTime(Optional.fromNullable(scheduledTime));
+        return setScheduledTime(Optional.ofNullable(scheduledTime));
     }
 
     public TDJobRequestBuilder setScheduledTime(Optional<Long> scheduledTime)
@@ -178,7 +179,7 @@ public class TDJobRequestBuilder
 
     public TDJobRequestBuilder setDomainKey(String domainKey)
     {
-        return setDomainKey(Optional.fromNullable(domainKey));
+        return setDomainKey(Optional.ofNullable(domainKey));
     }
 
     public Optional<Long> getResultConnectionId()
@@ -210,18 +211,18 @@ public class TDJobRequestBuilder
 
     public TDJobRequestBuilder setResultConnectionSettings(String resultConnectionSettings)
     {
-        return setResultConnectionSettings(Optional.fromNullable(resultConnectionSettings));
+        return setResultConnectionSettings(Optional.ofNullable(resultConnectionSettings));
     }
 
     public TDJobRequestBuilder setEngineVersion(String engineVersion)
     {
-        this.engineVersion = Optional.fromNullable(TDJob.EngineVersion.fromString(engineVersion));
+        this.engineVersion = Optional.ofNullable(TDJob.EngineVersion.fromString(engineVersion));
         return this;
     }
 
     public TDJobRequestBuilder setEngineVersion(TDJob.EngineVersion engineVersion)
     {
-        this.engineVersion = Optional.fromNullable(engineVersion);
+        this.engineVersion = Optional.ofNullable(engineVersion);
         return this;
     }
 

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryBuilder.java
@@ -18,22 +18,23 @@
  */
 package com.treasuredata.client.model;
 
-import com.google.common.base.Optional;
 import com.treasuredata.client.TDClientException;
+
+import java.util.Optional;
 
 public class TDSavedQueryBuilder
 {
-    private Optional<String> name = Optional.absent();
-    private Optional<String> cron = Optional.absent();
-    private Optional<TDJob.Type> type = Optional.absent();
-    private Optional<String> query = Optional.absent();
-    private Optional<String> timezone = Optional.absent();
-    private Optional<Long> delay = Optional.absent();
-    private Optional<String> database = Optional.absent();
-    private Optional<Integer> priority = Optional.absent();
-    private Optional<Integer> retryLimit = Optional.absent();
-    private Optional<String> result = Optional.absent();
-    private Optional<TDJob.EngineVersion> engineVersion = Optional.absent();
+    private Optional<String> name = Optional.empty();
+    private Optional<String> cron = Optional.empty();
+    private Optional<TDJob.Type> type = Optional.empty();
+    private Optional<String> query = Optional.empty();
+    private Optional<String> timezone = Optional.empty();
+    private Optional<Long> delay = Optional.empty();
+    private Optional<String> database = Optional.empty();
+    private Optional<Integer> priority = Optional.empty();
+    private Optional<Integer> retryLimit = Optional.empty();
+    private Optional<String> result = Optional.empty();
+    private Optional<TDJob.EngineVersion> engineVersion = Optional.empty();
 
     public TDSavedQueryBuilder setName(String name)
     {
@@ -97,7 +98,7 @@ public class TDSavedQueryBuilder
 
     public TDSavedQueryBuilder setEngineVersion(TDJob.EngineVersion engineVersion)
     {
-        this.engineVersion = Optional.fromNullable(engineVersion);
+        this.engineVersion = Optional.ofNullable(engineVersion);
         return this;
     }
 
@@ -118,16 +119,16 @@ public class TDSavedQueryBuilder
 
         return new TDSaveQueryRequest(
                 name.get(),
-                cron.or(""),
+                cron.orElse(""),
                 type.get(),
                 query.get(),
                 timezone.get(),
-                delay.or(0L),
+                delay.orElse(0L),
                 database.get(),
-                priority.or(TDJob.Priority.NORMAL.toInt()),
-                retryLimit.or(0),
-                result.or(""),
-                engineVersion.orNull()
+                priority.orElse(TDJob.Priority.NORMAL.toInt()),
+                retryLimit.orElse(0),
+                result.orElse(""),
+                engineVersion.orElse(null)
         );
     }
 

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryHistory.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryHistory.java
@@ -19,9 +19,9 @@
 package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 
 import java.util.List;
+import java.util.Optional;
 
 public class TDSavedQueryHistory
 {

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryStartRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryStartRequest.java
@@ -2,10 +2,10 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.base.Optional;
 import org.immutables.value.Value;
 
 import java.util.Date;
+import java.util.Optional;
 
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryStartRequestV4.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryStartRequestV4.java
@@ -3,11 +3,11 @@ package com.treasuredata.client.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.base.Optional;
 import org.immutables.value.Value;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Optional;
 import java.util.TimeZone;
 
 @Value.Immutable

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
@@ -19,7 +19,6 @@
 package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
@@ -19,13 +19,16 @@
 package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
+
+import java.util.Optional;
 
 /**
  * Update request for saved queries. Use {@link TDSavedQuery#newUpdateRequestBuilder()} to build this object.
@@ -78,6 +81,7 @@ public class TDSavedQueryUpdateRequest
         ObjectMapper mapper = new ObjectMapper();
         // Configure object mapper to exclude Optional.absent values in the generated json string
         mapper.registerModule(new GuavaModule().configureAbsentsAsNulls(false));
+        mapper.registerModule(new Jdk8Module());  // Required to make java.util.Optional serialize correctly
         mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
         return mapper;
     }
@@ -103,16 +107,16 @@ public class TDSavedQueryUpdateRequest
     public TDSaveQueryRequest merge(TDSavedQuery base)
     {
         return new TDSaveQueryRequest(
-                name.or(base.getName()),
-                cron.or(base.getCron()),
-                type.or(base.getType()),
-                query.or(base.getQuery()),
-                timezone.or(base.getTimezone()),
-                delay.or(base.getDelay()),
-                database.or(base.getDatabase()),
-                priority.or(base.getPriority()),
-                retryLimit.or(base.getRetryLimit()),
-                result.or(base.getResult()),
+                name.orElse(base.getName()),
+                cron.orElse(base.getCron()),
+                type.orElse(base.getType()),
+                query.orElse(base.getQuery()),
+                timezone.orElse(base.getTimezone()),
+                delay.orElse(base.getDelay()),
+                database.orElse(base.getDatabase()),
+                priority.orElse(base.getPriority()),
+                retryLimit.orElse(base.getRetryLimit()),
+                result.orElse(base.getResult()),
                 engineVersion.isPresent() ? engineVersion.get() : base.getEngineVersion());
     }
 

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequestBuilder.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequestBuilder.java
@@ -18,24 +18,24 @@
  */
 package com.treasuredata.client.model;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 /**
  *
  */
 public class TDSavedQueryUpdateRequestBuilder
 {
-    private Optional<String> name = Optional.absent();
-    private Optional<String> cron = Optional.absent();
-    private Optional<TDJob.Type> type = Optional.absent();
-    private Optional<String> query = Optional.absent();
-    private Optional<String> timezone = Optional.absent();
-    private Optional<Long> delay = Optional.absent();
-    private Optional<String> database = Optional.absent();
-    private Optional<Integer> priority = Optional.absent();
-    private Optional<Integer> retryLimit = Optional.absent();
-    private Optional<String> result = Optional.absent();
-    private Optional<TDJob.EngineVersion> engineVersion = Optional.absent();
+    private Optional<String> name = Optional.empty();
+    private Optional<String> cron = Optional.empty();
+    private Optional<TDJob.Type> type = Optional.empty();
+    private Optional<String> query = Optional.empty();
+    private Optional<String> timezone = Optional.empty();
+    private Optional<Long> delay = Optional.empty();
+    private Optional<String> database = Optional.empty();
+    private Optional<Integer> priority = Optional.empty();
+    private Optional<Integer> retryLimit = Optional.empty();
+    private Optional<String> result = Optional.empty();
+    private Optional<TDJob.EngineVersion> engineVersion = Optional.empty();
 
     TDSavedQueryUpdateRequestBuilder()
     {

--- a/src/main/java/com/treasuredata/client/model/TDUser.java
+++ b/src/main/java/com/treasuredata/client/model/TDUser.java
@@ -3,8 +3,10 @@ package com.treasuredata.client.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.base.Optional;
+
 import org.immutables.value.Value;
+
+import java.util.Optional;
 
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)

--- a/src/test/java/com/treasuredata/client/TDRequestErrorHandlerTest.java
+++ b/src/test/java/com/treasuredata/client/TDRequestErrorHandlerTest.java
@@ -1,6 +1,5 @@
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
 import com.treasuredata.client.model.TDApiErrorMessage;
 import okhttp3.Headers;
 import okhttp3.MediaType;
@@ -18,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
@@ -104,6 +103,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
@@ -801,7 +801,7 @@ public class TestTDClient
                 "secret access key",
                 "bucket",
                 "prefix/",
-                Optional.<String>absent());
+                Optional.<String>empty());
         client.createDatabaseIfNotExists(SAMPLE_DB);
         client.createTableIfNotExists(SAMPLE_DB, "sample_output");
         String jobId = client.submitExportJob(jobRequest);
@@ -893,7 +893,7 @@ public class TestTDClient
                 return Optional.of(table);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Test
@@ -1461,7 +1461,7 @@ public class TestTDClient
                 return Optional.of(q);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private void validateSavedQuery(TDSaveQueryRequest expected, TDSavedQuery target)

--- a/src/test/java/com/treasuredata/client/TestTDClientConfig.java
+++ b/src/test/java/com/treasuredata/client/TestTDClientConfig.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -32,6 +31,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -252,10 +252,10 @@ public class TestTDClientConfig
 
         assertThat(config.withApiKey("foo").apiKey, is(Optional.of("foo")));
         assertThat(config.withApiKey(Optional.of("foo")).apiKey, is(Optional.of("foo")));
-        assertThat(config.withApiKey(Optional.<String>absent()).apiKey, is(Optional.<String>absent()));
+        assertThat(config.withApiKey(Optional.<String>empty()).apiKey, is(Optional.<String>empty()));
         assertThat(config.withApiKey("foo").withApiKey("bar").apiKey, is(Optional.of("bar")));
-        assertThat(config.withApiKey("foo").withApiKey(Optional.<String>absent()).apiKey, is(Optional.<String>absent()));
-        assertThat(config.withApiKey(Optional.<String>absent()).withApiKey("bar").apiKey, is(Optional.of("bar")));
+        assertThat(config.withApiKey("foo").withApiKey(Optional.<String>empty()).apiKey, is(Optional.<String>empty()));
+        assertThat(config.withApiKey(Optional.<String>empty()).withApiKey("bar").apiKey, is(Optional.of("bar")));
     }
 
     private Matcher<Multimap<String, String>> equalTo(final Multimap<String, String> multimap)

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Optional;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -40,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -77,7 +77,7 @@ public class TestTDHttpClient
     public void addHttpRequestHeader()
     {
         TDApiRequest req = TDApiRequest.Builder.GET("/v3/system/server_status").addHeader("TEST_HEADER", "hello td-client-java").build();
-        String resp = client.submitRequest(req, Optional.<String>absent(), stringContentHandler);
+        String resp = client.submitRequest(req, Optional.<String>empty(), stringContentHandler);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class TestTDHttpClient
     {
         try {
             TDApiRequest req = TDApiRequest.Builder.DELETE("/v3/dummy_endpoint").build();
-            String resp = client.submitRequest(req, Optional.<String>absent(), stringContentHandler);
+            String resp = client.submitRequest(req, Optional.<String>empty(), stringContentHandler);
             fail();
         }
         catch (TDClientHttpException e) {
@@ -111,7 +111,7 @@ public class TestTDHttpClient
         final byte[] body = "foobar".getBytes("UTF-8");
         final long retryAfterSeconds = 5;
 
-        byte[] result = client.submitRequest(req, Optional.<String>absent(), new TDHttpRequestHandler<byte[]>()
+        byte[] result = client.submitRequest(req, Optional.<String>empty(), new TDHttpRequestHandler<byte[]>()
         {
             @Override
             public Response send(OkHttpClient httpClient, Request request)
@@ -169,7 +169,7 @@ public class TestTDHttpClient
                 .build()
                 .httpClient;
 
-        int requests = failWith429(Optional.<String>absent(), Optional.<Matcher<Date>>absent());
+        int requests = failWith429(Optional.<String>empty(), Optional.<Matcher<Date>>empty());
 
         assertThat(requests, is(4));
     }
@@ -184,7 +184,7 @@ public class TestTDHttpClient
                 .build()
                 .httpClient;
 
-        int requests = failWith429(Optional.of("foobar"), Optional.<Matcher<Date>>absent());
+        int requests = failWith429(Optional.of("foobar"), Optional.<Matcher<Date>>empty());
 
         assertThat(requests, is(4));
     }
@@ -267,7 +267,7 @@ public class TestTDHttpClient
         final byte[] body = new byte[3 * 1024 * 1024];
         Arrays.fill(body, (byte) 100);
 
-        byte[] res = client.submitRequest(req, Optional.<String>absent(), new TestDefaultHandler(body));
+        byte[] res = client.submitRequest(req, Optional.<String>empty(), new TestDefaultHandler(body));
         assertThat(res, is(body));
     }
 
@@ -311,7 +311,7 @@ public class TestTDHttpClient
         final TDApiRequest req = TDApiRequest.Builder.GET("/v3/system/server_status").build();
 
         try {
-            client.submitRequest(req, Optional.<String>absent(), new TDHttpRequestHandler<byte[]>()
+            client.submitRequest(req, Optional.<String>empty(), new TDHttpRequestHandler<byte[]>()
             {
                 @Override
                 public Response send(OkHttpClient httpClient, Request request)
@@ -347,7 +347,7 @@ public class TestTDHttpClient
             }
             TDClientHttpTooManyRequestsException tooManyRequestsException = (TDClientHttpTooManyRequestsException) e;
             if (retryAfterMatcher.isPresent()) {
-                assertThat(tooManyRequestsException.getRetryAfter().orNull(), retryAfterMatcher.get());
+                assertThat(tooManyRequestsException.getRetryAfter().orElse(null), retryAfterMatcher.get());
             }
         }
 

--- a/src/test/java/com/treasuredata/client/model/TDBulkLoadSessionStartRequestTest.java
+++ b/src/test/java/com/treasuredata/client/model/TDBulkLoadSessionStartRequestTest.java
@@ -1,6 +1,7 @@
 package com.treasuredata.client.model;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
+
 import org.junit.Test;
 
 import static com.treasuredata.client.model.ObjectMappers.compactMapper;
@@ -14,7 +15,7 @@ public class TDBulkLoadSessionStartRequestTest
     public void defaultValues()
             throws Exception
     {
-        assertThat(TDBulkLoadSessionStartRequest.builder().build().getScheduledTime(), is(Optional.<String>absent()));
+        assertThat(TDBulkLoadSessionStartRequest.builder().build().getScheduledTime(), is(Optional.<String>empty()));
     }
 
     @Test


### PR DESCRIPTION
Replaced all references to Guava Optional with java.util.Optional. There were a few cases where direct translation/support is not available in Java 1.8 Optional class (or at all). java.util.Optional is not serializable, etc. 

Note that there were two unit tests that were failing prior to the changes. 