### PR TITLE
Update maven url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ td-client-java is licensed under Apache License Version 2.0.
 
 ## Download
 
-You can download a jar file (td-client-java-(version)-shade.jar) from here: http://central.maven.org/maven2/com/treasuredata/client/td-client
+You can download a jar file (td-client-java-(version)-shade.jar) from here: https://repo1.maven.org/maven2/com/treasuredata/client/td-client/
 
 For the information of the older versions, see <https://github.com/treasure-data/td-client-java/tree/0.7.x>.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ client.jobResult(jobId, TDResultFormat.MESSAGE_PACK_GZ, new Function<InputStream
 
 }
 finally {
-  // Never forget to close the TDClient. 
+  // Never forget to close the TDClient.
   client.close();
 }
 ```


### PR DESCRIPTION
* fix maven URL 501

![image](https://user-images.githubusercontent.com/1247622/72710553-b24b9b80-3baa-11ea-85e5-c46da397d4dd.png)

```
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
```
