### PR TITLE
Upgrade okhttp to 3.12.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.12.0</version>
+      <version>3.12.10</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
3.12.0 -> 3.12.10 is an API compatible upgrade. 

- Several bugs that caused connection leak and crash are fixed https://square.github.io/okhttp/changelog_3x/#version-3126, https://square.github.io/okhttp/changelog_3x/#version-3122