### PR TITLE
Upgrade to okhttp 3.14.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,13 +99,13 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
-      <version>3.12.0</version>
+      <version>3.14.7</version>
     </dependency>
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>3.12.0</version>
+      <version>3.14.7</version>
       <scope>test</scope>
     </dependency>
 
@@ -275,7 +275,15 @@
           <relocations>
             <relocation>
               <pattern>com.google</pattern>
-              <shadedPattern>com.treasuredata.client.com.google</shadedPattern>
+              <shadedPattern>com.treasuredata.client.thirdparty.com.google</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>okhttp3</pattern>
+              <shadedPattern>com.treasuredata.client.thirdparty.okhttp3</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>okio</pattern>
+              <shadedPattern>com.treasuredata.client.thirdparty.okio</shadedPattern>
             </relocation>
           </relocations>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.12.10</version>
+      <version>3.14.7</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -41,7 +41,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.internal.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -309,11 +308,11 @@ public class TDHttpClient
 
     private static RequestBody createRequestBodyWithoutCharset(MediaType contentType, String content)
     {
-        Charset charset = Util.UTF_8;
+        Charset charset = StandardCharsets.UTF_8;
         if (contentType != null) {
             charset = contentType.charset();
             if (charset == null) {
-                charset = Util.UTF_8;
+                charset = StandardCharsets.UTF_8;
             }
         }
         byte[] bytes = content.getBytes(charset);
@@ -543,7 +542,7 @@ public class TDHttpClient
      * @return
      * @throws TDClientException
      */
-    @SuppressWarnings(value = "unchecked cast")
+    @SuppressWarnings(value = "unchecked")
     public <Result> Result call(TDApiRequest apiRequest, Optional<String> apiKeyCache, final JavaType resultType)
             throws TDClientException
     {


### PR DESCRIPTION
- Use the latest version of okhttp 3.x series, which supports HTTP2. Although td-client-java doesn't need to use HTTP2, the other components that use td-client-java can use HTTP2 with okhttp with this upgrade. 
- okhttp 4.x requires Kotlin, so sticking to 3.x series is better to avoid unnecessary dependencies.
- For applications sensitive to okhttp dependencies, the shade version td-client-shade.jar hides okhttp3 and okio packages.