### PR TITLE
Use https scheme to request to API endpoint

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Release 0.2.14.4 - 2020/06/02
+  IMPROVEMENTS
+    Replace HTTP by HTTPS to request to API endpoint.
+
 Release 0.2.14.3 - 2014/08/20
   IMPROVEMENTS
     Adds added new priority field to PerformSessionRequest model class.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>td-client</artifactId>
   <name>Treasure Data Client for Java</name>
   <description>Treasure Data Client for Java.</description>
-  <version>0.2.14.3</version>
+  <version>0.2.14.4</version>
   <packaging>jar</packaging>
   <url>https://github.com/treasure-data/td-client-java</url>
 

--- a/src/main/java/com/treasure_data/client/HttpConnectionImpl.java
+++ b/src/main/java/com/treasure_data/client/HttpConnectionImpl.java
@@ -114,7 +114,7 @@ public class HttpConnectionImpl {
     public void doGetRequest(Request<?> request, String path, Map<String, String> header,
             Map<String, String> params) throws IOException {
         StringBuilder sbuf = new StringBuilder();
-        sbuf.append("http://").append(getApiServerPath()).append(path);
+        sbuf.append("https://").append(getApiServerPath()).append(path);
 
         // parameters
         if (params != null && !params.isEmpty()) {
@@ -151,7 +151,7 @@ public class HttpConnectionImpl {
     public void doPostRequest(Request<?> request, String path, Map<String, String> header,
             Map<String, String> params) throws IOException {
         StringBuilder sbuf = new StringBuilder();
-        sbuf.append("http://").append(getApiServerPath()).append(path);
+        sbuf.append("https://").append(getApiServerPath()).append(path);
 
         // parameters
         if (params != null && !params.isEmpty()) {
@@ -192,7 +192,7 @@ public class HttpConnectionImpl {
     public void doPutRequest(Request<?> request, String path, byte[] bytes)
             throws IOException {
         StringBuilder sbuf = new StringBuilder();
-        sbuf.append("http://").append(getApiServerPath()).append(path);
+        sbuf.append("https://").append(getApiServerPath()).append(path);
 
         URL url = new URL(sbuf.toString());
         conn = (HttpURLConnection) url.openConnection();
@@ -217,7 +217,7 @@ public class HttpConnectionImpl {
     public void doPutRequest(Request<?> request, String path,
             InputStream in, int size) throws IOException {
         StringBuilder sbuf = new StringBuilder();
-        sbuf.append("http://").append(getApiServerPath()).append(path);
+        sbuf.append("https://").append(getApiServerPath()).append(path);
 
         URL url = new URL(sbuf.toString());
         conn = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
The old version `v0.2.14.3` is using HTTP to request to API endpoint. HTTP is unsecure and should be replaced by HTTPS.

The PR only updates the scheme from HTTP to HTTPS and should not impact to current stable version.