### PR TITLE
Fix errors when generating javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,4 +222,15 @@
     </plugins>
   </reporting>
 
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <doclint>none</doclint>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
PR will bring the new profile that disable strict javadoc lint check for Java 8.