### PR TITLE
Deprecate validateAPIKey

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -92,7 +92,7 @@ public interface TDClientApi<ClientImpl>
     TDUser getUser();
 
     /**
-     * @deprecated reason this API is deprecated since 202102.
+     * @deprecated reason this API is deprecated since February 2021.
      * Validates and return information about the current API key.
      * @return A {@link TDApiKey} instance.
      */

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -92,6 +92,7 @@ public interface TDClientApi<ClientImpl>
     TDUser getUser();
 
     /**
+     * @deprecated reason this API is deprecated since 202102.
      * Validates and return information about the current API key.
      * @return A {@link TDApiKey} instance.
      */


### PR DESCRIPTION
We plan to deprecate /v3/user/apikey/validate endpoint.
Instead of removing the code, I request to add deprecated annotation.