### PR TITLE
Fix the column order in append schema API

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -585,7 +585,6 @@ public class TDClient
 
         ImmutableList.Builder<List<String>> builder = ImmutableList.builder();
         for (TDColumn newColumn : newSchema) {
-            // TODO: Schema should be array of [name, type, key], not [key, type, name]. Kept for backward compatibility for now...
             builder.add(ImmutableList.of(newColumn.getKeyString(), newColumn.getType().toString(), newColumn.getName()));
         }
         String schemaJson = JSONObject.toJSONString(ImmutableMap.of("schema", builder.build(), "ignore_duplicate_schema", ignoreDuplicate));
@@ -602,8 +601,8 @@ public class TDClient
         ImmutableList.Builder<List<String>> builder = ImmutableList.builder();
         for (TDColumn appendedColumn : appendedSchema) {
             // Unlike update-schema API, append-schema API can generate alias for column name.
-            // So we should not pass `appendedColumn.getKeyString()` here.
-            builder.add(ImmutableList.of(appendedColumn.getName(), appendedColumn.getType().toString()));
+            // So we should not pass `appendedColumn.getName()` here.
+            builder.add(ImmutableList.of(appendedColumn.getKeyString(), appendedColumn.getType().toString()));
         }
         String schemaJson = JSONObject.toJSONString(ImmutableMap.of("schema", builder.build()));
         doPost(buildUrl("/v3/table/append-schema", databaseName, tableName), ImmutableMap.<String, String>of(), Optional.of(schemaJson), String.class);

--- a/src/main/java/com/treasuredata/client/model/TDColumn.java
+++ b/src/main/java/com/treasuredata/client/model/TDColumn.java
@@ -44,7 +44,7 @@ public class TDColumn implements Serializable
     // The column SQL alias.
     private final String name;
     private final TDColumnType type;
-    // The actual column name.
+    // The physical column name in partition files
     private final byte[] key;
 
     public TDColumn(String name, TDColumnType type)

--- a/src/main/java/com/treasuredata/client/model/TDColumn.java
+++ b/src/main/java/com/treasuredata/client/model/TDColumn.java
@@ -41,8 +41,10 @@ public class TDColumn implements Serializable
 {
     static final byte[] LOG_TABLE_PUSHDOWN_KEY = "time".getBytes(UTF_8);
 
+    // The column SQL alias.
     private final String name;
     private final TDColumnType type;
+    // The actual column name.
     private final byte[] key;
 
     public TDColumn(String name, TDColumnType type)


### PR DESCRIPTION
**Context:** The expected column order to use in append schema API is: `column name, column type, column SQL alias`. Because the existing attributes in `TDColumn` class are sometimes confusing:
* `name` is column SQL alias.
* `key` is column name.

That led the append schema API uses the wrong attribute, it should use `key` as a column name instead of `name` as a SQL alias. The PR brings the small patch to fix that issue. We might want to update the attributes in `TDColumn` to make it more obvious though.