### PR TITLE
Remove API Key validation test cases because it has been deprecated.

### DIFF
--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -35,7 +35,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 import com.treasuredata.client.model.ObjectMappers;
-import com.treasuredata.client.model.TDApiKey;
 import com.treasuredata.client.model.TDBulkImportSession;
 import com.treasuredata.client.model.TDBulkLoadSessionStartRequest;
 import com.treasuredata.client.model.TDBulkLoadSessionStartResult;
@@ -1388,34 +1387,6 @@ public class TestTDClient
     {
         TDUser user = client.getUser();
         logger.trace("user: {}", user);
-    }
-
-    @Test
-    public void validateApiKeyMocked()
-            throws Exception
-    {
-        client = mockClient();
-
-        String expectedKeyJson = "{\"user_id\":1,\"account_id\":2,\"key_type\":\"normal\",\"administrator\":true}";
-
-        TDApiKey expectedKey = ObjectMappers.compactMapper().readValue(expectedKeyJson, TDApiKey.class);
-
-        server.enqueue(new MockResponse().setBody(expectedKeyJson));
-
-        TDApiKey key = client.validateApiKey();
-
-        assertThat(key, is(expectedKey));
-
-        RecordedRequest recordedRequest = server.takeRequest();
-        assertThat(recordedRequest.getPath(), is("/v3/user/apikey/validate"));
-    }
-
-    @Test
-    public void validateApiKey()
-            throws Exception
-    {
-        TDApiKey key = client.validateApiKey();
-        logger.trace("api_key: {}", key);
     }
 
     @Test


### PR DESCRIPTION
Follow-up https://github.com/treasure-data/td-client-java/pull/164, because API key validation has been removed completely, thus its related test cases should be removed too.