### PR TITLE
Drop the test code for http endpoint

### DIFF
--- a/src/main/java/com/treasuredata/client/model/TDBulkImportSession.java
+++ b/src/main/java/com/treasuredata/client/model/TDBulkImportSession.java
@@ -157,7 +157,7 @@ public class TDBulkImportSession
         if (validRecords == 0) {
             return "No record processed";
         }
-        if (errorRecords > 0) {
+        if (errorParts > 0) {
             return String.format("%d invalid parts", errorParts);
         }
         if (errorRecords > 0) {

--- a/src/test/java/com/treasuredata/client/TestProxyAccess.java
+++ b/src/test/java/com/treasuredata/client/TestProxyAccess.java
@@ -135,23 +135,19 @@ public class TestProxyAccess
                 return new PasswordAuthentication(PROXY_USER, PROXY_PASS.toCharArray());
             }
         };
+        String disabledSchemesProperty = "jdk.http.auth.tunneling.disabledSchemes";
 
         try {
+            System.setProperty(disabledSchemesProperty, "");
             Authenticator.setDefault(auth);
-            // Non SSL access
-            try (InputStream in = new URL("http://api.treasuredata.com/v3/system/server_status").openConnection(proxy).getInputStream()) {
-                String ret = CharStreams.toString(new InputStreamReader(in));
-                logger.info(ret);
-            }
-            assertEquals(1, proxyAccessCount.get());
-
             try (InputStream in = new URL("https://api.treasuredata.com/v3/system/server_status").openConnection(proxy).getInputStream()) {
                 String ret = CharStreams.toString(new InputStreamReader(in));
                 logger.info(ret);
             }
-            assertEquals(2, proxyAccessCount.get());
+            assertEquals(1, proxyAccessCount.get());
         }
         finally {
+            System.clearProperty(disabledSchemesProperty);
             Authenticator.setDefault(null);
         }
     }


### PR DESCRIPTION
- TD http endpoints got disabled since Mar 1.
  https://docs.treasuredata.com/display/public/PD/March+2021+Release+Note#March2021ReleaseNote-EndofLifeforHTTPEndpoints
- JDK makes Basic authentication for HTTPS tunneling disabled by default in JDK 8u111 or higher.
    https://www.oracle.com/java/technologies/javase/8u111-relnotes.html
   To pass the test for authentication for HTTPS tunneling, we need to set `disabledSchemes` jvm property. 