### PR TITLE
Handle timeout at error body read

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClientException.java
+++ b/src/main/java/com/treasuredata/client/TDClientException.java
@@ -65,7 +65,7 @@ public class TDClientException
 
     public TDClientException(ErrorType errorType, String message, Optional<Exception> cause)
     {
-        super(formatErrorMessage(errorType, message, cause));
+        super(formatErrorMessage(errorType, message, cause), cause.orNull());
         checkNotNull(errorType, "errorType is null");
         checkNotNull(cause, "cause is null");
         this.errorType = errorType;

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -258,6 +258,11 @@ public class TDRequestErrorHandler
             try {
                 content = Optional.of(response.body().string());
             }
+            catch (SocketTimeoutException e) {
+                // http status was error or not found but failed to get body content
+                // handler by status will process further
+                return Optional.of(new TDApiErrorMessage(e.getClass().getSimpleName(), e.getMessage(), "error"));
+            }
             catch (IOException e) {
                 throw new TDClientException(INVALID_JSON_RESPONSE, e);
             }


### PR DESCRIPTION
When a server returns non success(200) error, the error handler expects a JSON serialized body which contains error details. But reading the error body could also raise an `IOException` and we wrap it as `INVALID_JSON_RESPONSE`.

As one of `IOException`, when `SocketTimeoutException` occurs, wrapping it as `INVALID_JSON_RESPONSE` would hide the timeout. Actually http status has already received, error details is useful for logging/auditing but might not be required. For example, 

* At 404 but timeout at reading error body : NOT_FOUND handler should process it even with the timeout 
* At 500 but timeout at reading error body : Retry handler should process it even with the timeout

