### PR TITLE
Upgrade Guava 31.1 and remove jackson-guava binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>31.1-jre</version>
     </dependency>
 
     <dependency>
@@ -133,12 +133,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson-core.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-guava</artifactId>
       <version>${jackson-core.version}</version>
     </dependency>
 

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
 import com.google.common.annotations.VisibleForTesting;
@@ -86,7 +85,6 @@ public class TDHttpClient
     // Used for reading JSON response
     static ObjectMapper defaultObjectMapper = new ObjectMapper()
             .registerModule(new JsonOrgModule()) // for mapping query json strings into JSONObject
-            .registerModule(new GuavaModule())   // for mapping to Guava Optional class
             .registerModule(new Jdk8Module())
             .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, false)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/com/treasuredata/client/model/ObjectMappers.java
+++ b/src/main/java/com/treasuredata/client/model/ObjectMappers.java
@@ -3,7 +3,6 @@ package com.treasuredata.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
 import com.google.common.annotations.VisibleForTesting;
@@ -36,7 +35,6 @@ public class ObjectMappers
     {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JsonOrgModule());
-        mapper.registerModule(new GuavaModule().configureAbsentsAsNulls(false));
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(false));
         mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
+++ b/src/main/java/com/treasuredata/client/model/TDSavedQueryUpdateRequest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -79,7 +78,6 @@ public class TDSavedQueryUpdateRequest
     {
         ObjectMapper mapper = new ObjectMapper();
         // Configure object mapper to exclude Optional.absent values in the generated json string
-        mapper.registerModule(new GuavaModule().configureAbsentsAsNulls(false));
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(false));
         mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
         return mapper;


### PR DESCRIPTION
Guava 31.1 has not been updated for a year since 2022. Using the latest version will reduce the chance of dependency hell. 

And also, jackson binding for Guava is no longer necessary as we have removed Guava Optional usage thanks to @exoego in #181 