### PR TITLE
Bye-bye guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,12 +113,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson-core.version}</version>


### PR DESCRIPTION
Closes #135 

`guava` dependency is no more needed after #215 