### PR TITLE
Deprecate Guava Multimap and Function in favor of JDK & Remove Guava collections

### DIFF
--- a/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
+++ b/src/main/java/com/treasuredata/client/AbstractTDClientBuilder.java
@@ -18,9 +18,12 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -66,7 +69,7 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
     protected int connectTimeoutMillis = 15000;
     protected int readTimeoutMillis = 60000;
     protected int connectionPoolSize = 64;
-    protected Multimap<String, String> headers = ImmutableMultimap.of();
+    protected Map<String, Collection<String>> headers = Collections.emptyMap();
 
     private static Optional<String> getConfigProperty(Properties p, TDClientConfig.Type key)
     {
@@ -328,9 +331,20 @@ public abstract class AbstractTDClientBuilder<ClientImpl, BuilderImpl extends Ab
         return self();
     }
 
+    /**
+     * @deprecated Use {@link #setHeaders(Map)} instead.
+     * @param headers
+     * @return
+     */
+    @Deprecated
     public BuilderImpl setHeaders(Multimap<String, String> headers)
     {
-        this.headers = ImmutableMultimap.copyOf(headers);
+        return this.setHeaders(headers.asMap());
+    }
+
+    public BuilderImpl setHeaders(Map<String, ? extends Collection<String>> headers)
+    {
+        this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
         return self();
     }
 

--- a/src/main/java/com/treasuredata/client/TDApiRequest.java
+++ b/src/main/java/com/treasuredata/client/TDApiRequest.java
@@ -18,19 +18,20 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Collections;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,7 +46,7 @@ public class TDApiRequest
     private final TDHttpMethod method;
     private final String path;
     private final Map<String, String> queryParams;
-    private final Multimap<String, String> headerParams;
+    private final Map<String, Collection<String>> headerParams;
     private final Optional<String> postJson;
     private final Optional<File> putFile;
     private final Optional<byte[]> content;
@@ -57,7 +58,7 @@ public class TDApiRequest
             TDHttpMethod method,
             String path,
             Map<String, String> queryParams,
-            Multimap<String, String> headerParams,
+            Map<String, Collection<String>> headerParams,
             Optional<String> postJson,
             Optional<File> putFile,
             Optional<byte[]> content,
@@ -80,7 +81,7 @@ public class TDApiRequest
 
     public TDApiRequest withUri(String uri)
     {
-        return new TDApiRequest(method, uri, ImmutableMap.copyOf(queryParams), ImmutableMultimap.copyOf(headerParams), postJson, putFile, content, contentOffset, contentLength, followRedirects);
+        return new TDApiRequest(method, uri, Collections.unmodifiableMap(new HashMap<>(queryParams)), Collections.unmodifiableMap(new HashMap<>(headerParams)), postJson, putFile, content, contentOffset, contentLength, followRedirects);
     }
 
     public String getPath()
@@ -98,7 +99,21 @@ public class TDApiRequest
         return queryParams;
     }
 
+    /**
+     * @deprecated Use {@link #getHeaderParamsV2()} instead.
+     * @return
+     */
+    @Deprecated
     public Multimap<String, String> getHeaderParams()
+    {
+        ImmutableMultimap.Builder<String, String> builder = new ImmutableMultimap.Builder<>();
+        for (Map.Entry<String, Collection<String>> e : headerParams.entrySet()) {
+            builder.putAll(e.getKey(), e.getValue());
+        }
+        return builder.build();
+    }
+
+    public Map<String, Collection<String>> getHeaderParamsV2()
     {
         return headerParams;
     }
@@ -135,12 +150,12 @@ public class TDApiRequest
 
     public static class Builder
     {
-        private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
-        private static final Multimap<String, String> EMPTY_HEADERS = ImmutableMultimap.of();
+        private static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
+        private static final Map<String, Collection<String>> EMPTY_HEADERS = Collections.emptyMap();
         private TDHttpMethod method;
         private String path;
         private Map<String, String> queryParams;
-        private ImmutableMultimap.Builder<String, String> headerParams;
+        private HashMap<String, Collection<String>> headerParams;
         private Optional<String> postJson = Optional.empty();
         private Optional<File> file = Optional.empty();
         private Optional<byte[]> content = Optional.empty();
@@ -176,19 +191,36 @@ public class TDApiRequest
 
         public Builder addHeader(String key, String value)
         {
-            if (headerParams == null) {
-                headerParams = ImmutableMultimap.builder();
-            }
-            headerParams.put(key, value);
-            return this;
+            return addHeaders(Collections.singletonMap(key, Collections.singletonList(value)));
         }
 
+        /**
+         * @deprecated Use {@link #addHeaders(Map)} instead.
+         * @param headers
+         * @return
+         */
+        @Deprecated
         public Builder addHeaders(Multimap<String, String> headers)
         {
+            return this.addHeaders(headers.asMap());
+        }
+
+        public Builder addHeaders(Map<String, ? extends Collection<String>> headers)
+        {
             if (headerParams == null) {
-                headerParams = ImmutableMultimap.builder();
+                headerParams = new HashMap<>();
             }
-            headerParams.putAll(headers);
+            for (Map.Entry<String, ? extends Collection<String>> e : headers.entrySet()) {
+                headerParams.compute(e.getKey(), (unused, list) -> {
+                    if (list == null) {
+                        return new ArrayList<>(e.getValue());
+                    }
+                    else {
+                        list.addAll(e.getValue());
+                        return list;
+                    }
+                });
+            }
             return this;
         }
 
@@ -233,7 +265,7 @@ public class TDApiRequest
                     method,
                     path,
                     queryParams != null ? queryParams : EMPTY_MAP,
-                    headerParams != null ? headerParams.build() : EMPTY_HEADERS,
+                    headerParams != null ? Collections.unmodifiableMap(new HashMap<>(headerParams)) : EMPTY_HEADERS,
                     postJson,
                     file,
                     content,

--- a/src/main/java/com/treasuredata/client/TDApiRequest.java
+++ b/src/main/java/com/treasuredata/client/TDApiRequest.java
@@ -100,7 +100,7 @@ public class TDApiRequest
     }
 
     /**
-     * @deprecated Use {@link #getHeaderParamsV2()} instead.
+     * @deprecated Use {@link #getAllHeaders()} instead.
      * @return
      */
     @Deprecated
@@ -113,7 +113,7 @@ public class TDApiRequest
         return builder.build();
     }
 
-    public Map<String, Collection<String>> getHeaderParamsV2()
+    public Map<String, Collection<String>> getAllHeaders()
     {
         return headerParams;
     }

--- a/src/main/java/com/treasuredata/client/TDApiRequest.java
+++ b/src/main/java/com/treasuredata/client/TDApiRequest.java
@@ -191,11 +191,11 @@ public class TDApiRequest
 
         public Builder addHeader(String key, String value)
         {
-            return addHeaders(Collections.singletonMap(key, Collections.singletonList(value)));
+            return addHeaders(key, Collections.singletonList(value));
         }
 
         /**
-         * @deprecated Use {@link #addHeaders(Map)} instead.
+         * @deprecated Use {@link #addHeaders(Map)} or {@link #addHeaders(String, Collection)} instead.
          * @param headers
          * @return
          */
@@ -205,23 +205,37 @@ public class TDApiRequest
             return this.addHeaders(headers.asMap());
         }
 
+        public Builder addHeaders(String key, Collection<String> values)
+        {
+            if (headerParams == null) {
+                headerParams = new HashMap<>();
+            }
+            addHeaderValues(key, values);
+            return this;
+        }
+
         public Builder addHeaders(Map<String, ? extends Collection<String>> headers)
         {
             if (headerParams == null) {
                 headerParams = new HashMap<>();
             }
             for (Map.Entry<String, ? extends Collection<String>> e : headers.entrySet()) {
-                headerParams.compute(e.getKey(), (unused, list) -> {
-                    if (list == null) {
-                        return new ArrayList<>(e.getValue());
-                    }
-                    else {
-                        list.addAll(e.getValue());
-                        return list;
-                    }
-                });
+                addHeaderValues(e.getKey(), e.getValue());
             }
             return this;
+        }
+
+        private void addHeaderValues(String key, Collection<String> values)
+        {
+            headerParams.compute(key, (unused, list) -> {
+                if (list == null) {
+                    return new ArrayList<>(values);
+                }
+                else {
+                    list.addAll(values);
+                    return list;
+                }
+            });
         }
 
         public Builder addQueryParam(String key, String value)

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Function;
 import com.google.common.collect.Multimap;
 import com.treasuredata.client.model.ObjectMappers;
 import com.treasuredata.client.model.TDApiKey;
@@ -76,6 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.treasuredata.client.model.ObjectMappers;
 import com.treasuredata.client.model.TDApiKey;
@@ -69,6 +67,9 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -143,8 +144,20 @@ public class TDClient
         return new TDClient(config, httpClient, Optional.of(newApiKey));
     }
 
+    /**
+     * @deprecated Use {@link #withHeaders(Map)} instead.
+     * @param headers
+     * @return
+     */
+    @Deprecated
     @Override
     public TDClient withHeaders(Multimap<String, String> headers)
+    {
+        return new TDClient(config, httpClient.withHeaders(headers), apiKeyCache);
+    }
+
+    @Override
+    public TDClient withHeaders(Map<String, ? extends Collection<String>> headers)
     {
         return new TDClient(config, httpClient.withHeaders(headers), apiKeyCache);
     }
@@ -240,7 +253,7 @@ public class TDClient
     protected <ResultType> ResultType doPost(String path, Class<ResultType> resultTypeClass)
             throws TDClientException
     {
-        return this.<ResultType>doPost(path, ImmutableMap.<String, String>of(), Optional.empty(), resultTypeClass);
+        return this.<ResultType>doPost(path, Collections.emptyMap(), Optional.empty(), resultTypeClass);
     }
 
     protected <ResultType> ResultType doPost(String path, Map<String, String> queryParam, Class<ResultType> resultTypeClass)
@@ -320,7 +333,10 @@ public class TDClient
     @Override
     public TDClient authenticate(String email, String password)
     {
-        TDAuthenticationResult authResult = doPost("/v3/user/authenticate", ImmutableMap.of("user", email, "password", password), TDAuthenticationResult.class);
+        Map<String, String> m = new HashMap<>();
+        m.put("user", email);
+        m.put("password", password);
+        TDAuthenticationResult authResult = doPost("/v3/user/authenticate", Collections.unmodifiableMap(m), TDAuthenticationResult.class);
         return withApiKey(authResult.getApikey());
     }
 
@@ -496,7 +512,7 @@ public class TDClient
     {
         // Idempotent key support is EXPERIMENTAL.
         doPost(buildUrl("/v3/table/create", databaseName, validateTableName(tableName), TDTableType.LOG.getTypeName()),
-                ImmutableMap.of("idempotent_key", idempotentKey));
+                Collections.singletonMap("idempotent_key", idempotentKey));
     }
 
     @Override
@@ -523,7 +539,7 @@ public class TDClient
             throws TDClientException
     {
         doPost(buildUrl("/v3/table/rename", databaseName, tableName, validateTableName(newTableName)),
-                ImmutableMap.of("overwrite", Boolean.toString(overwrite)),
+                Collections.singletonMap("overwrite", Boolean.toString(overwrite)),
                 TDUpdateTableResult.class
         );
     }
@@ -562,15 +578,15 @@ public class TDClient
             throw new TDClientException(TDClientException.ErrorType.INVALID_INPUT, String.format("from/to value must be a multiple of 3600: [%s, %s)", from, to));
         }
 
-        ImmutableMap.Builder<String, String> queryParams = ImmutableMap.<String, String>builder()
-                .put("from", Long.toString(from))
-                .put("to", Long.toString(to));
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("from", Long.toString(from));
+        queryParams.put("to", Long.toString(to));
 
         if (domainKey != null) {
             queryParams.put("domain_key", domainKey);
         }
 
-        TDPartialDeleteJob job = doPost(buildUrl("/v3/table/partialdelete", databaseName, tableName), queryParams.build(), TDPartialDeleteJob.class);
+        TDPartialDeleteJob job = doPost(buildUrl("/v3/table/partialdelete", databaseName, tableName), Collections.unmodifiableMap(queryParams), TDPartialDeleteJob.class);
         return job;
     }
 
@@ -593,12 +609,15 @@ public class TDClient
         requireNonNull(tableName, "tableName is null");
         requireNonNull(newSchema, "newSchema is null");
 
-        ImmutableList.Builder<List<String>> builder = ImmutableList.builder();
+        List<List<String>> builder = new ArrayList<>(newSchema.size());
         for (TDColumn newColumn : newSchema) {
-            builder.add(ImmutableList.of(newColumn.getKeyString(), newColumn.getType().toString(), newColumn.getName()));
+            builder.add(Arrays.asList(newColumn.getKeyString(), newColumn.getType().toString(), newColumn.getName()));
         }
-        String schemaJson = toJSONString(ImmutableMap.of("schema", builder.build(), "ignore_duplicate_schema", ignoreDuplicate));
-        doPost(buildUrl("/v3/table/update-schema", databaseName, tableName), ImmutableMap.<String, String>of(), Optional.of(schemaJson), String.class);
+        Map<String, Object> m = new HashMap<>();
+        m.put("schema", Collections.unmodifiableList(builder));
+        m.put("ignore_duplicate_schema", ignoreDuplicate);
+        String schemaJson = toJSONString(m);
+        doPost(buildUrl("/v3/table/update-schema", databaseName, tableName), Collections.emptyMap(), Optional.of(schemaJson), String.class);
     }
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -620,14 +639,14 @@ public class TDClient
         requireNonNull(tableName, "tableName is null");
         requireNonNull(appendedSchema, "appendedSchema is null");
 
-        ImmutableList.Builder<List<String>> builder = ImmutableList.builder();
+        List<List<String>> builder = new ArrayList<>(appendedSchema.size());
         for (TDColumn appendedColumn : appendedSchema) {
             // Unlike update-schema API, append-schema API can generate alias for column name.
             // So we should not pass `appendedColumn.getName()` here.
-            builder.add(ImmutableList.of(appendedColumn.getKeyString(), appendedColumn.getType().toString()));
+            builder.add(Arrays.asList(appendedColumn.getKeyString(), appendedColumn.getType().toString()));
         }
-        String schemaJson = toJSONString(ImmutableMap.of("schema", builder.build()));
-        doPost(buildUrl("/v3/table/append-schema", databaseName, tableName), ImmutableMap.<String, String>of(), Optional.of(schemaJson), String.class);
+        String schemaJson = toJSONString(Collections.singletonMap("schema", Collections.unmodifiableList(builder)));
+        doPost(buildUrl("/v3/table/append-schema", databaseName, tableName), Collections.emptyMap(), Optional.of(schemaJson), String.class);
     }
 
     @Override
@@ -806,9 +825,9 @@ public class TDClient
     {
         Optional<String> jsonBody = Optional.empty();
         if (poolName.isPresent()) {
-            jsonBody = Optional.of(toJSONString(ImmutableMap.of("pool_name", poolName.get())));
+            jsonBody = Optional.of(toJSONString(Collections.singletonMap("pool_name", poolName.get())));
         }
-        doPost(buildUrl("/v3/bulk_import/perform", sessionName), ImmutableMap.of("priority", Integer.toString(priority.toInt())), jsonBody, String.class);
+        doPost(buildUrl("/v3/bulk_import/perform", sessionName), Collections.singletonMap("priority", Integer.toString(priority.toInt())), jsonBody, String.class);
     }
 
     @Override
@@ -870,7 +889,7 @@ public class TDClient
 
         TDSavedQueryStartResultV4 result =
                 doPost(buildUrl("/v4/queries", Long.toString(request.id().get()), "jobs"),
-                        ImmutableMap.<String, String>of(),
+                        Collections.emptyMap(),
                         Optional.of(toJson(TDSavedQueryStartRequestV4.from(request))),
                         TDSavedQueryStartResultV4.class);
 
@@ -945,7 +964,7 @@ public class TDClient
         TDSavedQuery result =
                 doPost(
                         buildUrl("/v3/schedule/create", request.getName()),
-                        ImmutableMap.<String, String>of(),
+                        Collections.emptyMap(),
                         Optional.of(json),
                         TDSavedQuery.class);
         return result;
@@ -959,7 +978,7 @@ public class TDClient
         TDSavedQuery result =
                 doPost(
                         buildUrl("/v3/schedule/update", name),
-                        ImmutableMap.<String, String>of(),
+                        Collections.emptyMap(),
                         Optional.of(json),
                         TDSavedQuery.class);
         return result;
@@ -1029,7 +1048,7 @@ public class TDClient
     @Override
     public TDBulkLoadSessionStartResult startBulkLoadSession(String name, TDBulkLoadSessionStartRequest request)
     {
-        Map<String, String> queryParams = ImmutableMap.of();
+        Map<String, String> queryParams = Collections.emptyMap();
         String payload = null;
         try {
             payload = ObjectMappers.compactMapper().writeValueAsString(request);
@@ -1086,36 +1105,36 @@ public class TDClient
     @Override
     public TDImportResult importFile(String databaseName, String tableName, File file)
     {
-        return doPut(buildUrl(String.format("/v3/table/import/%s/%s/%s", databaseName, tableName, "msgpack.gz")), ImmutableMap.of(), file, TDImportResult.class);
+        return doPut(buildUrl(String.format("/v3/table/import/%s/%s/%s", databaseName, tableName, "msgpack.gz")), Collections.emptyMap(), file, TDImportResult.class);
     }
 
     @Override
     public TDImportResult importFile(String databaseName, String tableName, File file, String id)
     {
-        return doPut(buildUrl(String.format("/v3/table/import_with_id/%s/%s/%s/%s", databaseName, tableName, id, "msgpack.gz")), ImmutableMap.of(), file, TDImportResult.class);
+        return doPut(buildUrl(String.format("/v3/table/import_with_id/%s/%s/%s/%s", databaseName, tableName, id, "msgpack.gz")), Collections.emptyMap(), file, TDImportResult.class);
     }
 
     @Override
     public TDImportResult importBytes(String databaseName, String tableName, byte[] content)
     {
-        return doPut(buildUrl(String.format("/v3/table/import/%s/%s/%s", databaseName, tableName, "msgpack.gz")), ImmutableMap.of(), content, 0, content.length, TDImportResult.class);
+        return doPut(buildUrl(String.format("/v3/table/import/%s/%s/%s", databaseName, tableName, "msgpack.gz")), Collections.emptyMap(), content, 0, content.length, TDImportResult.class);
     }
 
     @Override
     public TDImportResult importBytes(String databaseName, String tableName, byte[] content, int offset, int length)
     {
-        return doPut(buildUrl(String.format("/v3/table/import/%s/%s/%s", databaseName, tableName, "msgpack.gz")), ImmutableMap.of(), content, offset, length, TDImportResult.class);
+        return doPut(buildUrl(String.format("/v3/table/import/%s/%s/%s", databaseName, tableName, "msgpack.gz")), Collections.emptyMap(), content, offset, length, TDImportResult.class);
     }
 
     @Override
     public TDImportResult importBytes(String databaseName, String tableName, byte[] content, String id)
     {
-        return doPut(buildUrl(String.format("/v3/table/import_with_id/%s/%s/%s/%s", databaseName, tableName, id, "msgpack.gz")), ImmutableMap.of(), content, 0, content.length, TDImportResult.class);
+        return doPut(buildUrl(String.format("/v3/table/import_with_id/%s/%s/%s/%s", databaseName, tableName, id, "msgpack.gz")), Collections.emptyMap(), content, 0, content.length, TDImportResult.class);
     }
 
     @Override
     public TDImportResult importBytes(String databaseName, String tableName, byte[] content, int offset, int length, String id)
     {
-        return doPut(buildUrl(String.format("/v3/table/import_with_id/%s/%s/%s/%s", databaseName, tableName, id, "msgpack.gz")), ImmutableMap.of(), content, offset, length, TDImportResult.class);
+        return doPut(buildUrl(String.format("/v3/table/import_with_id/%s/%s/%s/%s", databaseName, tableName, id, "msgpack.gz")), Collections.emptyMap(), content, offset, length, TDImportResult.class);
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -265,7 +265,7 @@ public interface TDClientApi<ClientImpl>
     @Deprecated
     default <Result> Result jobResult(String jobId, TDResultFormat format, com.google.common.base.Function<InputStream, Result> resultStreamHandler)
     {
-        return this.jobResult(jobId, format, resultStreamHandler::apply);
+        return this.jobResult(jobId, format, (Function<InputStream, Result>) resultStreamHandler::apply);
     }
 
     /**
@@ -314,7 +314,7 @@ public interface TDClientApi<ClientImpl>
     @Deprecated
     default <Result> Result getBulkImportErrorRecords(String sessionName, com.google.common.base.Function<InputStream, Result> resultStreamHandler)
     {
-       return this.getBulkImportErrorRecords(sessionName, resultStreamHandler::apply);
+       return this.getBulkImportErrorRecords(sessionName, (Function<InputStream, Result>) resultStreamHandler::apply);
     }
 
     <Result> Result getBulkImportErrorRecords(String sessionName, Function<InputStream, Result> resultStreamHandler);

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Multimap;
 import com.treasuredata.client.model.TDApiKey;
 import com.treasuredata.client.model.TDBulkImportSession;
@@ -53,6 +52,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Treasure Data Client API
@@ -256,6 +256,24 @@ public interface TDClientApi<ClientImpl>
      *
      * You will receive an empty stream if the query has not finished yet.
      *
+     * @deprecated Use {@link #jobResult(String, TDResultFormat, Function)} instead.
+     * @param jobId
+     * @param format
+     * @param resultStreamHandler
+     * @return
+     */
+    @Deprecated
+    default <Result> Result jobResult(String jobId, TDResultFormat format, com.google.common.base.Function<InputStream, Result> resultStreamHandler)
+    {
+        return this.jobResult(jobId, format, resultStreamHandler::apply);
+    }
+
+    /**
+     * Open an input stream to retrieve the job result.
+     * The input stream will be closed after this method
+     *
+     * You will receive an empty stream if the query has not finished yet.
+     *
      * @param jobId
      * @param format
      * @param resultStreamHandler
@@ -289,6 +307,15 @@ public interface TDClientApi<ClientImpl>
     void commitBulkImportSession(String sessionName);
 
     void deleteBulkImportSession(String sessionName);
+
+    /**
+     * @deprecated Use {@link #getBulkImportErrorRecords(String, Function)} instead.
+     */
+    @Deprecated
+    default <Result> Result getBulkImportErrorRecords(String sessionName, com.google.common.base.Function<InputStream, Result> resultStreamHandler)
+    {
+       return this.getBulkImportErrorRecords(sessionName, resultStreamHandler::apply);
+    }
 
     <Result> Result getBulkImportErrorRecords(String sessionName, Function<InputStream, Result> resultStreamHandler);
 

--- a/src/main/java/com/treasuredata/client/TDClientApi.java
+++ b/src/main/java/com/treasuredata/client/TDClientApi.java
@@ -18,6 +18,8 @@
  */
 package com.treasuredata.client;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 import com.google.common.base.Function;
@@ -72,9 +74,19 @@ public interface TDClientApi<ClientImpl>
      * This instance will share the same internal http client, so closing the returned client will invalidate the current instance.
      *
      * @param headers
+     * @deprecated Use {@link #withHeaders(Map)} instead
      * @return
      */
-    ClientImpl withHeaders(Multimap<String, String> headers);
+    @Deprecated ClientImpl withHeaders(Multimap<String, String> headers);
+
+    /**
+     * Return a TDClientApi implementation that uses the provided headers when making api requests.
+     * This instance will share the same internal http client, so closing the returned client will invalidate the current instance.
+     *
+     * @param headers
+     * @return
+     */
+    ClientImpl withHeaders(Map<String, ? extends Collection<String>> headers);
 
     /**
      * Perform user email and password based authentication and return a new client that will use apikey based authentication.

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
 import com.google.common.base.Function;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.treasuredata.client.impl.ProxyAuthenticator;
 import com.treasuredata.client.model.JsonCollectionRootName;
@@ -49,7 +48,10 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -59,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static com.treasuredata.client.TDApiRequest.urlEncode;
 import static com.treasuredata.client.TDClientException.ErrorType.INVALID_JSON_RESPONSE;
 import static com.treasuredata.client.TDHttpRequestHandler.ResponseContext;
@@ -97,7 +100,7 @@ public class TDHttpClient
     /**
      * Visible for testing.
      */
-    final Multimap<String, String> headers;
+    final Map<String, Collection<String>> headers;
 
     public TDHttpClient(TDClientConfig config)
     {
@@ -125,7 +128,7 @@ public class TDHttpClient
 
         // Build OkHttpClient
         this.httpClient = builder.build();
-        this.headers = ImmutableMultimap.copyOf(config.headers);
+        this.headers = config.headersV2;
 
         // Prepare jackson json-object mapper
         this.objectMapper = defaultObjectMapper;
@@ -136,7 +139,7 @@ public class TDHttpClient
         this(reference.config, reference.httpClient, reference.objectMapper, reference.headers);
     }
 
-    private TDHttpClient(TDClientConfig config, OkHttpClient httpClient, ObjectMapper objectMapper, Multimap<String, String> headers)
+    private TDHttpClient(TDClientConfig config, OkHttpClient httpClient, ObjectMapper objectMapper, Map<String, Collection<String>> headers)
     {
         this.config = config;
         this.httpClient = httpClient;
@@ -148,16 +151,28 @@ public class TDHttpClient
      * Get a {@link TDHttpClient} that uses the specified headers for each request. Reuses the same
      * underlying http client so closing the returned instance will return this instance as well.
      *
+     * @deprecated Use {@link #withHeaders(Map)} instead.
      * @param headers
      * @return
      */
+    @Deprecated
     public TDHttpClient withHeaders(Multimap<String, String> headers)
     {
-        Multimap<String, String> mergedHeaders = ImmutableMultimap.<String, String>builder()
-                .putAll(this.headers)
-                .putAll(headers)
-                .build();
-        return new TDHttpClient(config, httpClient, objectMapper, mergedHeaders);
+        return withHeaders(headers.asMap());
+    }
+
+    /**
+     * Get a {@link TDHttpClient} that uses the specified headers for each request. Reuses the same
+     * underlying http client so closing the returned instance will return this instance as well.
+     *
+     * @param headers
+     * @return
+     */
+    public TDHttpClient withHeaders(Map<String, ? extends Collection<String>> headers)
+    {
+        Map<String, Collection<String>> mergedHeaders = new HashMap<>(this.headers);
+        mergedHeaders.putAll(headers);
+        return new TDHttpClient(config, httpClient, objectMapper, Collections.unmodifiableMap(mergedHeaders));
     }
 
     ObjectMapper getObjectMapper()
@@ -228,7 +243,7 @@ public class TDHttpClient
         String dateHeader = RFC2822_FORMAT.get().format(new Date());
         StringJoiner joiner = new StringJoiner(",");
         joiner.add(getClientName());
-        for (String s : headers.get(USER_AGENT)) {
+        for (String s : headers.getOrDefault(USER_AGENT, Collections.emptyList())) {
             joiner.add(s);
         }
         String userAgent = joiner.toString();
@@ -241,9 +256,11 @@ public class TDHttpClient
         request = setTDAuthHeaders(request, dateHeader);
 
         // Set other headers
-        for (Map.Entry<String, String> entry : headers.entries()) {
-            if (!entry.getKey().equals(USER_AGENT)) {
-                request = request.addHeader(entry.getKey(), entry.getValue());
+        for (Map.Entry<String, Collection<String>> e : headers.entrySet()) {
+            if (!e.getKey().equals(USER_AGENT)) {
+                for (String v : e.getValue()) {
+                    request = request.addHeader(e.getKey(), v);
+                }
             }
         }
         for (Map.Entry<String, String> entry : apiRequest.getHeaderParams().entries()) {

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -61,7 +61,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static com.treasuredata.client.TDApiRequest.urlEncode;
 import static com.treasuredata.client.TDClientException.ErrorType.INVALID_JSON_RESPONSE;
 import static com.treasuredata.client.TDHttpRequestHandler.ResponseContext;
@@ -263,7 +262,7 @@ public class TDHttpClient
                 }
             }
         }
-        for (Map.Entry<String, Collection<String>> entry : apiRequest.getHeaderParamsV2().entrySet()) {
+        for (Map.Entry<String, Collection<String>> entry : apiRequest.getAllHeaders().entrySet()) {
             String k = entry.getKey();
             for (String v : entry.getValue()) {
                 request = request.addHeader(k, v);

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -263,8 +263,11 @@ public class TDHttpClient
                 }
             }
         }
-        for (Map.Entry<String, String> entry : apiRequest.getHeaderParams().entries()) {
-            request = request.addHeader(entry.getKey(), entry.getValue());
+        for (Map.Entry<String, Collection<String>> entry : apiRequest.getHeaderParamsV2().entrySet()) {
+            String k = entry.getKey();
+            for (String v : entry.getValue()) {
+                request = request.addHeader(k, v);
+            }
         }
 
         // Set API Key after setting the other headers

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
-import com.google.common.base.Function;
 import com.google.common.collect.Multimap;
 import com.treasuredata.client.impl.ProxyAuthenticator;
 import com.treasuredata.client.model.JsonCollectionRootName;
@@ -58,6 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -523,6 +523,20 @@ public class TDHttpClient
             logger.trace("response:\n{}", content);
         }
         return content;
+    }
+
+    /**
+     * @deprecated Use {@link #call(TDApiRequest, Optional, Function)} instead.
+     * @param apiRequest
+     * @param apiKeyCache
+     * @param contentStreamHandler
+     * @param <Result>
+     * @return
+     */
+    @Deprecated
+    public <Result> Result call(TDApiRequest apiRequest, Optional<String> apiKeyCache, final com.google.common.base.Function<InputStream, Result> contentStreamHandler)
+    {
+        return submitRequest(apiRequest, apiKeyCache, newByteStreamHandler(contentStreamHandler));
     }
 
     /**

--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
@@ -1,9 +1,9 @@
 package com.treasuredata.client;
 
-import com.google.common.base.Function;
 import okhttp3.ResponseBody;
 
 import java.io.InputStream;
+import java.util.function.Function;
 
 /**
  * Request handler implementations
@@ -17,6 +17,22 @@ public class TDHttpRequestHandlers
     public static final TDHttpRequestHandler<String> stringContentHandler = response -> response.body().string();
 
     public static final TDHttpRequestHandler<byte[]> byteArrayContentHandler = response -> response.body().bytes();
+
+    /**
+     * @deprecated Use {@link #newByteStreamHandler(Function)} instead.
+     * @param handler
+     * @return
+     * @param <Result>
+     */
+    @Deprecated
+    public static final <Result> TDHttpRequestHandler<Result> newByteStreamHandler(final com.google.common.base.Function<InputStream, Result> handler)
+    {
+        return response -> {
+            try (ResponseBody body = response.body()) {
+                return handler.apply(body.byteStream());
+            }
+        };
+    }
 
     public static final <Result> TDHttpRequestHandler<Result> newByteStreamHandler(final Function<InputStream, Result> handler)
     {

--- a/src/main/java/com/treasuredata/client/model/TDApiErrorMessage.java
+++ b/src/main/java/com/treasuredata/client/model/TDApiErrorMessage.java
@@ -20,8 +20,8 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -39,7 +39,7 @@ public class TDApiErrorMessage
             String text,
             String severity)
     {
-        this(error, text, severity, ImmutableMap.<String, Object>of());
+        this(error, text, severity, Collections.emptyMap());
     }
 
     @JsonCreator

--- a/src/main/java/com/treasuredata/client/model/TDColumnType.java
+++ b/src/main/java/com/treasuredata/client/model/TDColumnType.java
@@ -20,10 +20,10 @@ package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.ImmutableList;
 import com.treasuredata.client.model.impl.TDColumnTypeDeserializer;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -37,16 +37,16 @@ public class TDColumnType implements Serializable
     public static final TDColumnType DOUBLE = new TDColumnType(TDTypeName.DOUBLE, Collections.emptyList());
     public static final TDColumnType STRING = new TDColumnType(TDTypeName.STRING, Collections.emptyList());
 
-    public static final List<TDColumnType> primitiveTypes = ImmutableList.of(INT, LONG, FLOAT, DOUBLE, STRING);
+    public static final List<TDColumnType> primitiveTypes = Arrays.asList(INT, LONG, FLOAT, DOUBLE, STRING);
 
     public static TDColumnType newArrayType(TDColumnType elementType)
     {
-        return new TDColumnType(TDTypeName.ARRAY, ImmutableList.of(elementType));
+        return new TDColumnType(TDTypeName.ARRAY, Collections.singletonList(elementType));
     }
 
     public static TDColumnType newMapType(TDColumnType keyType, TDColumnType valueType)
     {
-        return new TDColumnType(TDTypeName.MAP, ImmutableList.of(keyType, valueType));
+        return new TDColumnType(TDTypeName.MAP, Arrays.asList(keyType, valueType));
     }
 
     private final TDTypeName typeName;

--- a/src/main/java/com/treasuredata/client/model/impl/TDScheduleRunResult.java
+++ b/src/main/java/com/treasuredata/client/model/impl/TDScheduleRunResult.java
@@ -20,9 +20,10 @@ package com.treasuredata.client.model.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import com.treasuredata.client.model.TDJob;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -78,7 +79,7 @@ public class TDScheduleRunResult
     @JsonCreator
     public TDScheduleRunResult(@JsonProperty("jobs") List<Job> jobs)
     {
-        this.jobs = ImmutableList.copyOf(jobs);
+        this.jobs = Collections.unmodifiableList(new ArrayList<>(jobs));
     }
 
     @JsonProperty("jobs")

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.collect.ImmutableMultimap;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -40,6 +39,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -95,7 +95,7 @@ public class TestTDHttpClient
         assertEquals("td-client-java unknown", request1.header(USER_AGENT));
 
         // With specifying User-Agent header
-        TDHttpClient newClient = client.withHeaders(ImmutableMultimap.of(USER_AGENT, "td-sample-client 1.0"));
+        TDHttpClient newClient = client.withHeaders(Collections.singletonMap(USER_AGENT, Collections.singletonList("td-sample-client 1.0")));
         Request request2 = newClient.prepareRequest(apiRequest, Optional.empty());
         assertEquals("td-client-java unknown,td-sample-client 1.0", request2.header(USER_AGENT));
     }

--- a/src/test/java/com/treasuredata/client/model/TestTDColumn.java
+++ b/src/test/java/com/treasuredata/client/model/TestTDColumn.java
@@ -19,7 +19,6 @@
 package com.treasuredata.client.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -85,7 +84,7 @@ public class TestTDColumn
     public void parsePrimitiveColumnTypes()
     {
         // primitive type set
-        Set<TDColumnType> primitives = ImmutableSet.copyOf(TDColumnType.primitiveTypes);
+        Set<TDColumnType> primitives = new HashSet<>(TDColumnType.primitiveTypes);
 
         // primitive types
         for (String name : new String[] {"int", "long", "float", "double", "string"}) {


### PR DESCRIPTION
Part of #135 

This is the final Guava deprecation and removal.
After this PR and a new minor version cut, I think we could delete the deprecated one and guava dependency.

The problem is `Multimap<K, V>`. How should we remove it?
Possible directions:

1. Just replace it with `Map<K, Collection<V>>` and introduce breaking change aggressively. 
2. Add new overloads with `Map<K, Col<V>>` and deprecate the old methods with `Muiltimap`.
    - In this direction, some classes require new members to avoid conflict with `TDClientConfig#headers` and `TDApiRequest#getHeaderParams()`. See new members `~V2`. 

I propose picking 2nd since it helps users to migrate.
WDYT?