### PR TITLE
CI: Cache Maven deps to speed up test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  maven: circleci/maven@1.4.0
 jobs:
   build:
     working_directory: /tmp/td-client-java
@@ -6,8 +8,11 @@ jobs:
       - image: cimg/openjdk:8.0
     steps:
       - checkout
-      - run:
-          name: Test
-          command: mvn test -Dtd.client.endpoint=api-staging.treasuredata.com
+      - maven/with_cache:
+          steps:
+            - run:
+                name: Test
+                command: mvn test -Dtd.client.endpoint=api-staging.treasuredata.com
+      - maven/process_test_results
       - store_artifacts:
             path: /tmp/td-client-java/target/site


### PR DESCRIPTION
See https://circleci.com/developer/ja/orbs/orb/circleci/maven

- `curcleci/maven` orb is now used. It handles maven caching with less code.
- CircleCI config is bumped to `2.1`. This is required to use the CirlceCI orb. Otherwise `maven/with_cache` command is not recognized.

With cache hit | Without cache hit 
---|---
6s | 13s
<img width="487" alt="image" src="https://user-images.githubusercontent.com/127635/214575303-2b08111e-ed2f-4eb4-847b-c820d49b8175.png"> | <img width="460" alt="image" src="https://user-images.githubusercontent.com/127635/214576083-39fa6775-4f82-4f85-8d6b-972ff19b870b.png">

Not so impressive enhancements 😅 
