### PR TITLE
Make TDHttpRequestHandler FunctionalInterface

### DIFF
--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandler.java
@@ -13,6 +13,7 @@ import static com.treasuredata.client.TDRequestErrorHandler.defaultHttpResponseE
 /**
  *
  */
+@FunctionalInterface
 public interface TDHttpRequestHandler<Result>
 {
     static class ResponseContext

--- a/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
+++ b/src/main/java/com/treasuredata/client/TDHttpRequestHandlers.java
@@ -1,7 +1,6 @@
 package com.treasuredata.client;
 
 import com.google.common.base.Function;
-import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 import java.io.InputStream;
@@ -15,37 +14,15 @@ public class TDHttpRequestHandlers
     {
     }
 
-    public static final TDHttpRequestHandler<String> stringContentHandler = new TDHttpRequestHandler<String>()
-    {
-        @Override
-        public String onSuccess(Response response)
-                throws Exception
-        {
-            return response.body().string();
-        }
-    };
+    public static final TDHttpRequestHandler<String> stringContentHandler = response -> response.body().string();
 
-    public static final TDHttpRequestHandler<byte[]> byteArrayContentHandler = new TDHttpRequestHandler<byte[]>()
-    {
-        @Override
-        public byte[] onSuccess(Response response)
-                throws Exception
-        {
-            return response.body().bytes();
-        }
-    };
+    public static final TDHttpRequestHandler<byte[]> byteArrayContentHandler = response -> response.body().bytes();
 
     public static final <Result> TDHttpRequestHandler<Result> newByteStreamHandler(final Function<InputStream, Result> handler)
     {
-        return new TDHttpRequestHandler<Result>()
-        {
-            @Override
-            public Result onSuccess(Response response)
-                    throws Exception
-            {
-                try (ResponseBody body = response.body()) {
-                    return handler.apply(body.byteStream());
-                }
+        return response -> {
+            try (ResponseBody body = response.body()) {
+                return handler.apply(body.byteStream());
             }
         };
     }


### PR DESCRIPTION
This allows `TDHttpRequestHandler` in lambda notation for many use-cases.