### PR TITLE
Inline Guava Throwables.propagate

### DIFF
--- a/src/main/java/com/treasuredata/client/TDApiRequest.java
+++ b/src/main/java/com/treasuredata/client/TDApiRequest.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -251,7 +250,7 @@ public class TDApiRequest
             return URLEncoder.encode(value, "UTF-8");
         }
         catch (UnsupportedEncodingException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
@@ -1020,7 +1019,7 @@ public class TDClient
             payload = ObjectMappers.compactMapper().writeValueAsString(request);
         }
         catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         return doPost(buildUrl("/v3/bulk_loads", name, "jobs"),
                 queryParams, Optional.of(payload),

--- a/src/main/java/com/treasuredata/client/model/TDQuery.java
+++ b/src/main/java/com/treasuredata/client/model/TDQuery.java
@@ -21,7 +21,6 @@ package com.treasuredata.client.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 
 import java.io.StringWriter;
 
@@ -54,7 +53,7 @@ public class TDQuery
             return new TDQuery(s.toString());
         }
         catch (java.io.IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/com/treasuredata/client/Example.java
+++ b/src/test/java/com/treasuredata/client/Example.java
@@ -19,7 +19,6 @@
 package com.treasuredata.client;
 
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import com.treasuredata.client.model.TDDatabase;
 import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobRequest;
@@ -94,7 +93,7 @@ public class Example
                         unpacker.close();
                     }
                     catch (Exception e) {
-                        throw Throwables.propagate(e);
+                        throw new RuntimeException(e);
                     }
                     return count;
                 }

--- a/src/test/java/com/treasuredata/client/TestTDClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDClient.java
@@ -25,7 +25,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
@@ -391,7 +390,7 @@ public class TestTDClient
                     return new JSONArray(result);
                 }
                 catch (Exception e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         });
@@ -420,7 +419,7 @@ public class TestTDClient
                     return null;
                 }
                 catch (IOException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         });
@@ -601,7 +600,7 @@ public class TestTDClient
                     return new JSONArray(result);
                 }
                 catch (Exception e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         });
@@ -1029,7 +1028,7 @@ public class TestTDClient
                     return result;
                 }
                 catch (IOException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         });
@@ -1278,7 +1277,7 @@ public class TestTDClient
                         return errorRecordCount;
                     }
                     catch (IOException e) {
-                        throw Throwables.propagate(e);
+                        throw new RuntimeException(e);
                     }
                 }
             });


### PR DESCRIPTION
Part of #135

https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate
> In many cases, you'll be able to use throw e or throw new RuntimeException(e) with no change in behavior. This sometimes lets you remove other code.