### PR TITLE
Replace Guava net module with JDK equivalents

### DIFF
--- a/src/main/java/com/treasuredata/client/TDClient.java
+++ b/src/main/java/com/treasuredata/client/TDClient.java
@@ -77,7 +77,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -185,7 +184,7 @@ public class TDClient
         s.append(urlPrefix);
         for (String a : args) {
             s.append("/");
-            s.append(urlPathSegmentEscaper().escape(a));
+            s.append(UrlPathSegmentEscaper.escape(a));
         }
         return s.toString();
     }
@@ -1034,7 +1033,7 @@ public class TDClient
     @Override
     public long lookupConnection(String name)
     {
-        return doGet(buildUrl("/v3/connections/lookup?name=" + urlPathSegmentEscaper().escape(name)), TDConnectionLookupResult.class).getId();
+        return doGet(buildUrl("/v3/connections/lookup?name=" + UrlPathSegmentEscaper.escape(name)), TDConnectionLookupResult.class).getId();
     }
 
     @Override

--- a/src/main/java/com/treasuredata/client/TDHttpClient.java
+++ b/src/main/java/com/treasuredata/client/TDHttpClient.java
@@ -59,11 +59,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static com.google.common.net.HttpHeaders.AUTHORIZATION;
-import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
-import static com.google.common.net.HttpHeaders.DATE;
-import static com.google.common.net.HttpHeaders.LOCATION;
-import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static com.treasuredata.client.TDApiRequest.urlEncode;
 import static com.treasuredata.client.TDClientException.ErrorType.INVALID_JSON_RESPONSE;
 import static com.treasuredata.client.TDHttpRequestHandler.ResponseContext;
@@ -78,6 +73,12 @@ public class TDHttpClient
         implements AutoCloseable
 {
     private static final Logger logger = LoggerFactory.getLogger(TDHttpClient.class);
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final String DATE = "Date";
+    private static final String LOCATION = "Location";
+    private static final String USER_AGENT = "User-Agent";
 
     // Used for reading JSON response
     static ObjectMapper defaultObjectMapper = new ObjectMapper()

--- a/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
+++ b/src/main/java/com/treasuredata/client/TDRequestErrorHandler.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.google.common.net.HttpHeaders.RETRY_AFTER;
 import static com.treasuredata.client.TDClientException.ErrorType.CLIENT_ERROR;
 import static com.treasuredata.client.TDClientException.ErrorType.INVALID_INPUT;
 import static com.treasuredata.client.TDClientException.ErrorType.INVALID_JSON_RESPONSE;
@@ -43,6 +42,8 @@ import static com.treasuredata.client.TDHttpRequestHandler.ResponseContext;
  */
 public class TDRequestErrorHandler
 {
+    private static final String RETRY_AFTER = "Retry-After";
+
     private TDRequestErrorHandler()
     {
     }

--- a/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
+++ b/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Escape URL path segment in a compatible way with com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
+ */
 final class UrlPathSegmentEscaper
 {
     private UrlPathSegmentEscaper()
@@ -31,8 +34,8 @@ final class UrlPathSegmentEscaper
         return sb.toString();
     }
 
-    private static final Pattern NO_ESCAPE_CHARS = Pattern.compile("\\+|%(?:2[146789BC]|3[ABD]|7E|40)");
-    private static final Map<String, String> REPLACEMENT_TABLE;
+    private static final Pattern GUAVA_INCOMPATIBLE = Pattern.compile("\\+|%(?:2[146789BC]|3[ABD]|7E|40)");
+    private static final Map<String, String> REPLACEMENT_MAP;
     static {
         Map<String, String> m = new HashMap<>();
         m.put("+", "%20");
@@ -49,14 +52,14 @@ final class UrlPathSegmentEscaper
         m.put("%3D", "=");
         m.put("%7E", "~");
         m.put("%40", "@");
-        REPLACEMENT_TABLE = Collections.unmodifiableMap(m);
+        REPLACEMENT_MAP = Collections.unmodifiableMap(m);
     }
 
     static String escape(String s)
     {
         try {
             String encoded = URLEncoder.encode(s, "UTF-8");
-            return replaceWithMap(encoded, NO_ESCAPE_CHARS, REPLACEMENT_TABLE);
+            return replaceWithMap(encoded, GUAVA_INCOMPATIBLE, REPLACEMENT_MAP);
         }
         catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
+++ b/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
@@ -2,6 +2,11 @@ package com.treasuredata.client;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 final class UrlPathSegmentEscaper
 {
@@ -9,25 +14,49 @@ final class UrlPathSegmentEscaper
     {
     }
 
+    private static String replaceWithMap(String text, Pattern pattern, Map<String, String> map)
+    {
+        Matcher matcher = pattern.matcher(text);
+        if (!matcher.find()) {
+            return text;
+        }
+        StringBuilder sb = new StringBuilder();
+        int previousEnd = 0;
+        do {
+            sb.append(text.subSequence(previousEnd, matcher.start()));
+            sb.append(map.get(matcher.toMatchResult().group()));
+            previousEnd = matcher.end();
+        } while (matcher.find());
+        sb.append(text.subSequence(previousEnd, text.length()));
+        return sb.toString();
+    }
+
+    private static final Pattern NO_ESCAPE_CHARS = Pattern.compile("\\+|%(?:2[146789BC]|3[ABD]|7E|40)");
+    private static final Map<String, String> REPLACEMENT_TABLE;
+    static {
+        Map<String, String> m = new HashMap<>();
+        m.put("+", "%20");
+        m.put("%21", "!");
+        m.put("%24", "$");
+        m.put("%26", "&");
+        m.put("%27", "'");
+        m.put("%28", "(");
+        m.put("%29", ")");
+        m.put("%2B", "+");
+        m.put("%2C", ",");
+        m.put("%3A", ":");
+        m.put("%3B", ";");
+        m.put("%3D", "=");
+        m.put("%7E", "~");
+        m.put("%40", "@");
+        REPLACEMENT_TABLE = Collections.unmodifiableMap(m);
+    }
+
     static String escape(String s)
     {
         try {
             String encoded = URLEncoder.encode(s, "UTF-8");
-            return encoded
-                    .replaceAll("\\+", "%20")
-                    .replaceAll("%21", "!")
-                    .replaceAll("%24", "\\$")
-                    .replaceAll("%26", "&")
-                    .replaceAll("%27", "'")
-                    .replaceAll("%28", "(")
-                    .replaceAll("%29", ")")
-                    .replaceAll("%2B", "+")
-                    .replaceAll("%2C", ",")
-                    .replaceAll("%3A", ":")
-                    .replaceAll("%3B", ";")
-                    .replaceAll("%3D", "=")
-                    .replaceAll("%7E", "~")
-                    .replaceAll("%40", "@");
+            return replaceWithMap(encoded, NO_ESCAPE_CHARS, REPLACEMENT_TABLE);
         }
         catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
+++ b/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.treasuredata.client;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
+++ b/src/main/java/com/treasuredata/client/UrlPathSegmentEscaper.java
@@ -1,0 +1,36 @@
+package com.treasuredata.client;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+final class UrlPathSegmentEscaper
+{
+    private UrlPathSegmentEscaper()
+    {
+    }
+
+    static String escape(String s)
+    {
+        try {
+            String encoded = URLEncoder.encode(s, "UTF-8");
+            return encoded
+                    .replaceAll("\\+", "%20")
+                    .replaceAll("%21", "!")
+                    .replaceAll("%24", "\\$")
+                    .replaceAll("%26", "&")
+                    .replaceAll("%27", "'")
+                    .replaceAll("%28", "(")
+                    .replaceAll("%29", ")")
+                    .replaceAll("%2B", "+")
+                    .replaceAll("%2C", ",")
+                    .replaceAll("%3A", ":")
+                    .replaceAll("%3B", ";")
+                    .replaceAll("%3D", "=")
+                    .replaceAll("%7E", "~")
+                    .replaceAll("%40", "@");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/treasuredata/client/impl/ProxyAuthenticator.java
@@ -32,14 +32,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Optional;
 
-import static com.google.common.net.HttpHeaders.PROXY_AUTHORIZATION;
-
 /**
  *
  */
 public class ProxyAuthenticator
         implements Authenticator
 {
+    private static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
     private final Logger logger = LoggerFactory.getLogger(ProxyAuthenticator.class);
     private final ProxyConfig proxyConfig;
     private Optional<String> proxyAuthCache = Optional.empty();

--- a/src/test/java/com/treasuredata/client/TestServerFailures.java
+++ b/src/test/java/com/treasuredata/client/TestServerFailures.java
@@ -18,7 +18,6 @@
  */
 package com.treasuredata.client;
 
-import com.google.common.net.HttpHeaders;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -52,6 +51,8 @@ import static org.junit.Assert.fail;
  */
 public class TestServerFailures
 {
+    private static final String CONTENT_TYPE = "Content-Type";
+
     private static Logger logger = LoggerFactory.getLogger(TestServerFailures.class);
 
     private MockWebServer server;
@@ -275,8 +276,8 @@ public class TestServerFailures
     public void corruptedJsonResponse()
             throws Exception
     {
-        server.enqueue(new MockResponse().setBody("{broken json}").setHeader(HttpHeaders.CONTENT_TYPE, "plain/text"));
-        server.enqueue(new MockResponse().setBody("{\"database\":1}").setHeader(HttpHeaders.CONTENT_TYPE, "plain/text"));
+        server.enqueue(new MockResponse().setBody("{broken json}").setHeader(CONTENT_TYPE, "plain/text"));
+        server.enqueue(new MockResponse().setBody("{\"database\":1}").setHeader(CONTENT_TYPE, "plain/text"));
         server.start(port);
 
         TDClient client = TDClient

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -45,7 +45,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static com.treasuredata.client.TDHttpRequestHandlers.stringContentHandler;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -60,6 +59,8 @@ import static org.junit.Assert.fail;
  */
 public class TestTDHttpClient
 {
+    private static final String USER_AGENT = "User-Agent";
+
     private static Logger logger = LoggerFactory.getLogger(TestTDHttpClient.class);
     private TDHttpClient client;
 

--- a/src/test/java/com/treasuredata/client/TestUrlEscaper.java
+++ b/src/test/java/com/treasuredata/client/TestUrlEscaper.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.treasuredata.client;
+
+import org.junit.Test;
+
+import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Ensure compatibility with com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
+ */
+public class TestUrlEscaper
+{
+    @Test
+    public void nonAscii()
+    {
+        String v = urlPathSegmentEscaper().escape("あ漢ü");
+        assertEquals("%E3%81%82%E6%BC%A2%C3%BC", v);
+    }
+
+    @Test
+    public void emoji()
+    {
+        String v = urlPathSegmentEscaper().escape("🇸🇨");
+        assertEquals("%F0%9F%87%B8%F0%9F%87%A8", v);
+    }
+
+    @Test
+    public void specialChars()
+    {
+        String v = urlPathSegmentEscaper().escape("-_.~!*'();:@&=+$,/?%#[]^¥|{}\\<> ");
+        assertEquals("-_.~!*'();:@&=+$,%2F%3F%25%23%5B%5D%5E%C2%A5%7C%7B%7D%5C%3C%3E%20", v);
+    }
+
+    @Test
+    public void alphaNum()
+    {
+        String v = urlPathSegmentEscaper().escape("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        assertEquals("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", v);
+    }
+}

--- a/src/test/java/com/treasuredata/client/TestUrlPathSegmentEscaper.java
+++ b/src/test/java/com/treasuredata/client/TestUrlPathSegmentEscaper.java
@@ -20,39 +20,45 @@ package com.treasuredata.client;
 
 import org.junit.Test;
 
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 import static org.junit.Assert.assertEquals;
 
 /**
  * Ensure compatibility with com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
  */
-public class TestUrlEscaper
+public class TestUrlPathSegmentEscaper
 {
     @Test
     public void nonAscii()
     {
-        String v = urlPathSegmentEscaper().escape("あ漢ü");
-        assertEquals("%E3%81%82%E6%BC%A2%C3%BC", v);
+        String v = UrlPathSegmentEscaper.escape("あ漢ü🇸🇨");
+        assertEquals("%E3%81%82%E6%BC%A2%C3%BC%F0%9F%87%B8%F0%9F%87%A8", v);
     }
 
     @Test
-    public void emoji()
+    public void space()
     {
-        String v = urlPathSegmentEscaper().escape("🇸🇨");
-        assertEquals("%F0%9F%87%B8%F0%9F%87%A8", v);
+        String v = UrlPathSegmentEscaper.escape(" ");
+        assertEquals("%20", v);
     }
 
     @Test
-    public void specialChars()
+    public void specialCharsUnescaped()
     {
-        String v = urlPathSegmentEscaper().escape("-_.~!*'();:@&=+$,/?%#[]^¥|{}\\<> ");
-        assertEquals("-_.~!*'();:@&=+$,%2F%3F%25%23%5B%5D%5E%C2%A5%7C%7B%7D%5C%3C%3E%20", v);
+        String v = UrlPathSegmentEscaper.escape("-_.~!*'();:@&=+$,");
+        assertEquals("-_.~!*'();:@&=+$,", v);
+    }
+
+    @Test
+    public void specialCharsEscaped()
+    {
+        String v = UrlPathSegmentEscaper.escape("/?%#[]^¥|{}\\<>");
+        assertEquals("%2F%3F%25%23%5B%5D%5E%C2%A5%7C%7B%7D%5C%3C%3E", v);
     }
 
     @Test
     public void alphaNum()
     {
-        String v = urlPathSegmentEscaper().escape("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        String v = UrlPathSegmentEscaper.escape("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
         assertEquals("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", v);
     }
 }


### PR DESCRIPTION
Part of #135 

- HTTP Header constants are all inlined.
- `UrlPathSegmentEscaper` class is added. This class is compatible with `com.google.common.net.UrlEscapers.urlPathSegmentEscaper`.