### PR TITLE
testdep: Replace joda-time with JDK8 equivalents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,14 +241,6 @@
       <version>2.0.8</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.1</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/src/test/java/com/treasuredata/client/TDRequestErrorHandlerTest.java
+++ b/src/test/java/com/treasuredata/client/TDRequestErrorHandlerTest.java
@@ -7,15 +7,13 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 
@@ -74,8 +72,8 @@ public class TDRequestErrorHandlerTest
 
         long now = System.currentTimeMillis();
         Date d = TDRequestErrorHandler.parseRetryAfter(now, response);
-        Instant retryAfter = new Instant(d);
-        Instant expected = new DateTime(1999, 12, 31, 23, 59, 59, DateTimeZone.UTC).toInstant();
+        Instant retryAfter = d.toInstant();
+        Instant expected = Instant.parse("1999-12-31T23:59:59Z");
         assertThat(retryAfter, is(expected));
     }
 
@@ -94,8 +92,8 @@ public class TDRequestErrorHandlerTest
         long now = System.currentTimeMillis();
 
         Date d = TDRequestErrorHandler.parseRetryAfter(now, response);
-        Instant retryAfter = new Instant(d);
-        Instant expected = new DateTime(now).plusSeconds(120).toInstant();
+        Instant retryAfter = d.toInstant();
+        Instant expected = Instant.ofEpochMilli(now).plusSeconds(120);
         assertThat(retryAfter, is(expected));
     }
 }

--- a/src/test/java/com/treasuredata/client/TestTDHttpClient.java
+++ b/src/test/java/com/treasuredata/client/TestTDHttpClient.java
@@ -28,9 +28,6 @@ import okhttp3.ResponseBody;
 import org.exparity.hamcrest.date.DateMatchers;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +35,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
@@ -242,13 +243,13 @@ public class TestTDHttpClient
 
         // A late Retry-After value to verify that the exception is propagated without any retries when
         // the Retry-After value exceeds the configured retryLimit * retryMaxInterval
-        DateTime retryAfter = new DateTime().plusSeconds(4711);
-        DateTimeFormatter httpDateFormatter = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss zzz");
-        String retryAfterString = retryAfter.toString(httpDateFormatter);
+        ZonedDateTime retryAfter = ZonedDateTime.now(ZoneId.systemDefault()).plusSeconds(4711);
+        DateTimeFormatter httpDateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz");
+        String retryAfterString = httpDateFormatter.format(retryAfter);
 
         int requests = failWith429(
                 Optional.of(retryAfterString),
-                Optional.of(DateMatchers.within(30, SECONDS, retryAfter.toDate())));
+                Optional.of(DateMatchers.within(30, ChronoUnit.SECONDS, retryAfter.toLocalDateTime())));
 
         // Verify that only one attempt was made
         assertThat(requests, is(1));


### PR DESCRIPTION
JDK 8 introduced Date-and-Time, inspired by joda-time.
We no longer need joda-time for testing.