### PR TITLE
Bump OkHttp to v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <jackson-core.version>2.14.2</jackson-core.version>
     <jackson-bind.version>2.14.2</jackson-bind.version>
 
-    <okhttp.version>3.14.9</okhttp.version>
+    <okhttp.version>4.10.0</okhttp.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
## Why ?

OkHttp v3 series no longer get maintenance.
The last version v3.14.9 was published in about 3 years ago (2020-05-17).
> https://github.com/square/okhttp
> These platforms lack support for TLS 1.2 and should not be used. But because upgrading is difficult, we will backport critical fixes to the [3.12.x branch](https://github.com/square/okhttp/tree/okhttp_3.12.x) through December 31, 2021.

## Is it safe to bump to v4?

It is safe since we shade OkHttp dependencies.

In addition to that, OkHttp v4 offers:
> https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4/
> Binary compatibility is the ability to compile a program against OkHttp 3.x, and then to run it against OkHttp 4.x. We’re using the excellent [japicmp](https://github.com/siom79/japicmp) library via its [Gradle plugin](https://github.com/melix/japicmp-gradle-plugin) to enforce binary compatibility.
> Java source compatibility is the ability to upgrade Java uses of OkHttp 3.x to 4.x without changing .java files.
