### PR TITLE
Clean up dependency libraries and etc / Improve pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,12 +172,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
-    </dependency>
-
     <!-- ==================== -->
     <!-- Testing dependencies -->
     <!-- ==================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@
           <source>${project.build.targetJdk}</source>
           <encoding>${project.build.sourceEncoding}</encoding>
           <maxmemory>${project.build.jvmsize}</maxmemory>
-          <additionalparam>${javadoc.opts}</additionalparam>
+          <additionalOptions>${javadoc.opts}</additionalOptions>
         </configuration>
         <executions>
           <execution>
@@ -512,7 +512,7 @@
             <artifactId>umlgraph</artifactId>
             <version>5.6</version>
           </docletArtifact>
-          <additionalparam>-views -all</additionalparam>
+          <additionalOptions>-views -all</additionalOptions>
           <useStandardDocletOptions>true</useStandardDocletOptions>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -161,14 +161,14 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <version>2.2.10</version>
+      <version>2.10.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>builder</artifactId>
-      <version>2.2.10</version>
+      <version>2.10.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -196,14 +196,14 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.10.0</version>
+      <version>5.12.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.bigtesting</groupId>
       <artifactId>fixd</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -216,7 +216,7 @@
     <dependency>
       <groupId>xyz.rogfam</groupId>
       <artifactId>littleproxy</artifactId>
-      <version>2.0.15</version>
+      <version>2.2.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -450,20 +450,20 @@
             <goals>
               <goal>check</goal>
             </goals>
-            <configuration>
-              <failOnViolation>true</failOnViolation>
-              <consoleOutput>true</consoleOutput>
-              <includeTestSourceDirectory>true</includeTestSourceDirectory>
-              <configLocation>check-style.xml</configLocation>
-              <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+          <failOnViolation>true</failOnViolation>
+          <consoleOutput>true</consoleOutput>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <configLocation>check-style.xml</configLocation>
+          <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+        </configuration>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.45.1</version>
+            <version>9.3</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
     <dependency>
       <groupId>xyz.rogfam</groupId>
       <artifactId>littleproxy</artifactId>
-      <version>2.2.0</version>
+      <version>2.0.15</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Overview

- Delete `javax.annotation-api` from dependency libraries
- Update `org.immutables:*` to `2.10.1`
- Fix configurations in maven-javadoc-plugin
- Upgrade checkstyle to v9 