### PR TITLE
Fix missing compile scope dependencies in released POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shade</shadedClassifierName>
             </configuration>


### PR DESCRIPTION
The compile scope dependencies are missing from the released POM since 0.9.7. e.g. https://repo1.maven.org/maven2/com/treasuredata/client/td-client/0.9.7/td-client-0.9.7.pom

This was caused by the maven-shade-plugin update in #192. Previously, maven-shade-plugin did not create the dependency reduced POM when [shadedArtifactAttached](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#shadedArtifactAttached) was enabled, but in 3.3.0 the behavior changes and the plugin creates the dependency reduced POM regardless of the shadedArtifactAttached setting ([MSHADE-321](https://issues.apache.org/jira/browse/MSHADE-321)).

The problem is that the plugin not only creates the dependency reduced POM but also [modifies the current project model to use the generated POM](https://github.com/apache/maven-shade-plugin/blob/maven-shade-plugin-3.5.1/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java#L1126), which affects subsequent Maven executions ([MSHADE-419](https://issues.apache.org/jira/browse/MSHADE-419)).

As a workaround, we can stop creating the dependency reduced POM by disabling [createDependencyReducedPom](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#createDependencyReducedPom).