### PR TITLE
Add central-publishing-maven-plugin plugin to publish to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,18 @@
     <plugins>
 
       <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>


### PR DESCRIPTION
Since we move from OSSRH to Central Portal, we need central-publishing-maven-plugin to publish according to this guide:
https://central.sonatype.org/publish/publish-portal-maven